### PR TITLE
Add defaultURLSession and its delegate instead of instancePair

### DIFF
--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -111,12 +111,13 @@ public class API {
         }
     }
 
-    // send request and build response object
+    // this methods can be removed in Swift 1.2
     public class func sendRequest<T: Request>(request: T, handler: (Result<T.Response, NSError>) -> Void = {r in}) -> NSURLSessionDataTask? {
         return sendRequest(request, URLSession: defaultURLSession, handler: handler)
     }
 
-    public class func sendRequest<T: Request>(request: T, URLSession: NSURLSession, handler: (Result<T.Response, NSError>) -> Void = {r in}) -> NSURLSessionDataTask? {
+    // send request and build response object
+    public class func sendRequest<T: Request>(request: T, URLSession: NSURLSession = defaultURLSession, handler: (Result<T.Response, NSError>) -> Void = {r in}) -> NSURLSessionDataTask? {
         let mainQueue = dispatch_get_main_queue()
         
         if let URLRequest = request.URLRequest {

--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -56,10 +56,13 @@ private extension NSURLSessionDataTask {
 }
 
 // use private, global scope variable until we can use stored class var in Swift 1.2
-private var instancePairDictionary = [String: (API, NSURLSession)]()
-private let instancePairSemaphore = dispatch_semaphore_create(1)
+private let internalDefaultURLSession = NSURLSession(
+    configuration: NSURLSessionConfiguration.defaultSessionConfiguration(),
+    delegate: URLSessionDelegate(),
+    delegateQueue: nil
+)
 
-public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
+public class API {
     // configurations
     public class func baseURL() -> NSURL {
         fatalError("API.baseURL() must be overrided in subclasses.")
@@ -72,47 +75,9 @@ public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
     public class func responseBodyParser() -> ResponseBodyParser {
         return .JSON(readingOptions: nil)
     }
-    
-    public class func URLSessionConfiguration() -> NSURLSessionConfiguration {
-        return NSURLSessionConfiguration.defaultSessionConfiguration()
-    }
-    
-    public class func URLSessionDelegateQueue() -> NSOperationQueue? {
-        // nil indicates NSURLSession creates its own serial operation queue.
-        // see doc of NSURLSession.init(configuration:delegate:delegateQueue:) for more details.
-        return nil
-    }
-    
-    // prevent instantiation
-    override private init() {
-        super.init()
-    }
-    
-    // create session and instance of API for each subclasses
-    private final class var instancePair: (API, NSURLSession) {
-        let className = NSStringFromClass(self)
-        
-        dispatch_semaphore_wait(instancePairSemaphore, DISPATCH_TIME_FOREVER)
-        let pair: (API, NSURLSession) = instancePairDictionary[className] ?? {
-            let instance = (self as NSObject.Type)() as API
-            let configuration = self.URLSessionConfiguration()
-            let queue = self.URLSessionDelegateQueue()
-            let session = NSURLSession(configuration: configuration, delegate: instance, delegateQueue: queue)
-            let pair = (instance, session)
-            instancePairDictionary[className] = pair
-            return pair
-        }()
-        dispatch_semaphore_signal(instancePairSemaphore)
-        
-        return pair
-    }
-    
-    public final class var instance: API {
-        return instancePair.0
-    }
-    
-    public final class var URLSession: NSURLSession {
-        return instancePair.1
+
+    public class var defaultURLSession: NSURLSession {
+        return internalDefaultURLSession
     }
 
     // build NSURLRequest
@@ -148,11 +113,14 @@ public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
 
     // send request and build response object
     public class func sendRequest<T: Request>(request: T, handler: (Result<T.Response, NSError>) -> Void = {r in}) -> NSURLSessionDataTask? {
-        let session = URLSession
+        return sendRequest(request, URLSession: defaultURLSession, handler: handler)
+    }
+
+    public class func sendRequest<T: Request>(request: T, URLSession: NSURLSession, handler: (Result<T.Response, NSError>) -> Void = {r in}) -> NSURLSessionDataTask? {
         let mainQueue = dispatch_get_main_queue()
         
         if let URLRequest = request.URLRequest {
-            let task = session.dataTaskWithRequest(URLRequest)
+            let task = URLSession.dataTaskWithRequest(URLRequest)
             
             task.completionHandler = { data, URLResponse, connectionError in
                 if let error = connectionError {
@@ -192,9 +160,10 @@ public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
             return nil
         }
     }
-    
+}
+
+public class URLSessionDelegate: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
     // MARK: - NSURLSessionTaskDelegate
-    // TODO: add attributes like NS_REQUIRES_SUPER when it is available in future version of Swift.
     public func URLSession(session: NSURLSession, task: NSURLSessionTask, didCompleteWithError connectionError: NSError?) {
         if let dataTask = task as? NSURLSessionDataTask {
             dataTask.completionHandler?(dataTask.responseBuffer, dataTask.response, connectionError)
@@ -202,8 +171,7 @@ public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
     }
 
     // MARK: - NSURLSessionDataDelegate
-    // TODO: add attributes like NS_REQUIRES_SUPER when it is available in future version of Swift.
     public func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveData data: NSData) {
         dataTask.responseBuffer.appendData(data)
-    }
+    }    
 }

--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -111,13 +111,18 @@ public class API {
         }
     }
 
-    // this methods can be removed in Swift 1.2
+    // In Swift 1.1, we could not omit `URLSession` argument of `func send(request:URLSession(=default):handler(=default):)`
+    // with trailing closure, so we provide following 2 methods
+    // - `func sendRequest(request:handler(=default):)`
+    // - `func sendRequest(request:URLSession:handler(=default):)`.
+    // In Swift 1.2, we can omit default arguments with trailing closure, so they should be replaced with
+    // - `func sendRequest(request:URLSession(=default):handler(=default):)`
     public class func sendRequest<T: Request>(request: T, handler: (Result<T.Response, NSError>) -> Void = {r in}) -> NSURLSessionDataTask? {
         return sendRequest(request, URLSession: defaultURLSession, handler: handler)
     }
 
     // send request and build response object
-    public class func sendRequest<T: Request>(request: T, URLSession: NSURLSession = defaultURLSession, handler: (Result<T.Response, NSError>) -> Void = {r in}) -> NSURLSessionDataTask? {
+    public class func sendRequest<T: Request>(request: T, URLSession: NSURLSession, handler: (Result<T.Response, NSError>) -> Void = {r in}) -> NSURLSessionDataTask? {
         let mainQueue = dispatch_get_main_queue()
         
         if let URLRequest = request.URLRequest {

--- a/APIKitTests/APITests.swift
+++ b/APIKitTests/APITests.swift
@@ -41,21 +41,6 @@ class APITests: XCTestCase {
         super.tearDown()
     }
     
-    // MARK: - instance tests
-    func testDifferentSessionsAreCreatedForEachClasses() {
-        assert(MockAPI.URLSession, !=, AnotherMockAPI.URLSession)
-    }
-    
-    func testSameSessionsAreUsedInSameClasses() {
-        assertEqual(MockAPI.URLSession, MockAPI.URLSession)
-        assertEqual(AnotherMockAPI.URLSession, AnotherMockAPI.URLSession)
-    }
-    
-    func testDelegateOfSessions() {
-        assertNotNil(MockAPI.URLSession.delegate as? MockAPI)
-        assertNotNil(AnotherMockAPI.URLSession.delegate as? AnotherMockAPI)
-    }
-    
     // MARK: - integration tests
     func testSuccess() {
         let dictionary = ["key": "value"]

--- a/README.md
+++ b/README.md
@@ -171,11 +171,11 @@ class GitHub: API {
 
 ### NSURLSessionDelegate
 
-You can add custom behavior of `NSURLSession` by following steps:
+You can add custom behaviors of `NSURLSession` by following steps:
 
-1. Create subclass of `URLSessionDelegate` (e.g. `MyAPIURLSessionDelegate`).
+1. Create a subclass of `URLSessionDelegate` (e.g. `MyAPIURLSessionDelegate`).
 2. Implement additional delegate methods in it.
-3. Override `defaultURLSession` of `API` and return `NSURLSession` that has `MyURLSessionDelegate` as a delegate.
+3. Override `defaultURLSession` of `API` and return `NSURLSession` that has `MyURLSessionDelegate` as its delegate.
 
 This can add following features:
 

--- a/README.md
+++ b/README.md
@@ -169,19 +169,21 @@ class GitHub: API {
 
 ## Advanced usage
 
-
 ### NSURLSessionDelegate
 
-APIKit creates singleton instances for each subclasses of API and set them as delegates of NSURLSession,
-so you can add following features by implementing delegate methods.
+You can add custom behavior of `NSURLSession` by following steps:
+
+1. Create subclass of `URLSessionDelegate` (e.g. `MyAPIURLSessionDelegate`).
+2. Implement additional delegate methods in it.
+3. Override `defaultURLSession` of `API` and return `NSURLSession` that has `MyURLSessionDelegate` as a delegate.
+
+This can add following features:
 
 - Hook events of NSURLSession
 - Handle authentication challenges
 - Convert a data task to NSURLSessionDownloadTask
 
-#### Overriding delegate methods implemented by API
-
-API class also uses delegate methods of NSURLSession to implement wrapper of NSURLSession, so you should call super if you override following methods.
+NOTE: `URLSessionDelegate` also implements delegate methods of `NSURLSession` to implement wrapper of `NSURLSession`, so you should call super if you override following methods.
 
 - `func URLSession(session:task:didCompleteWithError:)`
 - `func URLSession(session:dataTask:didReceiveData:)`


### PR DESCRIPTION
This resolves #13. This change makes implementation simpler and more obvious.

- Add defaultURLSession that has a delegate with minimal implementation of NSURLSessionDataDelegate.
- Remove instance pair, which is singleton instance pair of API and NSURLSession.

Breaking changes:
- `API` does not creates singleton instances for each API subclasses. If an `API` subclass needs a separated session, `defaultURLSession` should be overrided.
- `API.instance` is no longer available.
- `API.session` is no longer available.
- Delegate methods implemented in `API` should be moved to custom delegate class, and its instance should be set to delegate of `defaultURLSession`.

See the discussion on #13 for more details.