### PR TITLE
Add `responseErrorFromObject` to create detailed error using response object

### DIFF
--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -115,8 +115,8 @@ public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
         return instancePair.1
     }
 
-    public class var acceptableStatusCodeRange: Range<Int> {
-        return 200..<300
+    public class var acceptableStatusCodes: [Int] {
+        return [Int](200..<300)
     }
 
     // build NSURLRequest
@@ -165,7 +165,7 @@ public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
                 }
                 
                 let statusCode = (URLResponse as? NSHTTPURLResponse)?.statusCode ?? 0
-                if !contains(self.acceptableStatusCodeRange, statusCode) {
+                if !contains(self.acceptableStatusCodes, statusCode) {
                     let error: NSError = {
                         switch self.responseBodyParser().parseData(data) {
                         case .Success(let box): return self.responseErrorFromObject(box.unbox)

--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -166,7 +166,7 @@ public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
                 
                 let statusCode = (URLResponse as? NSHTTPURLResponse)?.statusCode ?? 0
                 if !contains(self.acceptableStatusCodeRange, statusCode) {
-                    var error: NSError = {
+                    let error: NSError = {
                         switch self.responseBodyParser().parseData(data) {
                         case .Success(let box): return self.responseErrorFromObject(box.unbox)
                         case .Failure(let box): return box.unbox

--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -115,6 +115,10 @@ public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
         return instancePair.1
     }
 
+    public class var acceptableStatusCodeRange: Range<Int> {
+        return 200..<300
+    }
+
     // build NSURLRequest
     public class func URLRequest(method: Method, _ path: String, _ parameters: [String: AnyObject] = [:]) -> NSURLRequest? {
         if let components = NSURLComponents(URL: baseURL(), resolvingAgainstBaseURL: true) {
@@ -161,7 +165,7 @@ public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
                 }
                 
                 let statusCode = (URLResponse as? NSHTTPURLResponse)?.statusCode ?? 0
-                if !contains(200..<300, statusCode) {
+                if !contains(self.acceptableStatusCodeRange, statusCode) {
                     let userInfo = [NSLocalizedDescriptionKey: "received status code that represents error"]
                     let error = NSError(domain: APIKitErrorDomain, code: statusCode, userInfo: userInfo)
                     dispatch_async(mainQueue, { handler(.Failure(Box(error))) })

--- a/APIKitTests/APITests.swift
+++ b/APIKitTests/APITests.swift
@@ -17,6 +17,10 @@ class APITests: XCTestCase {
         override class func responseBodyParser() -> ResponseBodyParser {
             return .JSON(readingOptions: nil)
         }
+
+        override class func responseErrorFromObject(object: AnyObject) -> NSError {
+            return NSError(domain: "MockAPIErrorDomain", code: 10000, userInfo: nil)
+        }
         
         class Endpoint {
             class Get: Request {
@@ -118,7 +122,8 @@ class APITests: XCTestCase {
         OHHTTPStubs.stubRequestsPassingTest({ request in
             return true
         }, withStubResponse: { request in
-            return OHHTTPStubsResponse(data: NSData(), statusCode: 400, headers: nil)
+            let data = NSJSONSerialization.dataWithJSONObject([:], options: nil, error: nil)!
+            return OHHTTPStubsResponse(data: data, statusCode: 400, headers: nil)
         })
         
         let expectation = expectationWithDescription("wait for response")
@@ -131,8 +136,8 @@ class APITests: XCTestCase {
                 
             case .Failure(let box):
                 let error = box.unbox
-                assertEqual(error.domain, APIKitErrorDomain)
-                assertEqual(error.code, 400)
+                assertEqual(error.domain, "MockAPIErrorDomain")
+                assertEqual(error.code, 10000)
             }
             
             expectation.fulfill()


### PR DESCRIPTION
Resolves #15.