### PR TITLE
Add `cancelRequest(_:passingTest:)` for cancellation

### DIFF
--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -36,7 +36,7 @@ extension NSURLSessionTask {
         let downloadTask: AnyObject = NSURLSession.sharedSession().downloadTaskWithRequest(NSURLRequest())
         let uploadTask: AnyObject = NSURLSession.sharedSession().uploadTaskWithRequest(NSURLRequest(), fromData: NSData())
         
-        // On iOS 7, `dataTask is NSURLSessionTask` returns false
+        // On iOS 7 and Mac OS 10.9, `dataTask is NSURLSessionTask` returns false
         if !(dataTask is NSURLSessionTask) {
             func bindClass(concreteClass: AnyClass, withClass abstractClass: AnyClass) {
                 let method = class_getInstanceMethod(concreteClass, "isKindOfClass:")

--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -260,5 +260,9 @@ public class URLSessionDelegate: NSObject, NSURLSessionDelegate, NSURLSessionDat
     // MARK: - NSURLSessionDataDelegate
     public func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveData data: NSData) {
         dataTask.responseBuffer.appendData(data)
-    }    
+    }
+    
+    public func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didBecomeDownloadTask downloadTask: NSURLSessionDownloadTask) {
+        downloadTask.request = dataTask.request
+    }
 }

--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -58,17 +58,16 @@ extension NSURLSessionTask {
         }
     }
 
-    // - `var request: Request?` is not available in both of Swift 1.1 and 1.2 ("protocol can only be used as a generic constraint")
-    // - `var request: Any?` is not available in Swift 1.1 (Swift compliler fails with segmentation fault)
-    // so Box<Any>? is used here for now
-    private var request: Box<Any>? {
+    // `var request: Request?` is not available in both of Swift 1.1 and 1.2
+    // ("protocol can only be used as a generic constraint")
+    private var request: Any? {
         get {
-            return objc_getAssociatedObject(self, &taskRequestKey) as? Box<Any>
+            return (objc_getAssociatedObject(self, &taskRequestKey) as? Box<Any>)?.unbox
         }
         
         set {
             if let value = newValue {
-                objc_setAssociatedObject(self, &taskRequestKey, value, UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+                objc_setAssociatedObject(self, &taskRequestKey, Box(value), UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
             } else {
                 objc_setAssociatedObject(self, &taskRequestKey, nil, UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
             }
@@ -179,7 +178,7 @@ public class API {
         if let URLRequest = request.URLRequest {
             let task = URLSession.dataTaskWithRequest(URLRequest)
             
-            task.request = Box(request)
+            task.request = request
             task.completionHandler = { data, URLResponse, connectionError in
                 if let error = connectionError {
                     dispatch_async(mainQueue, { handler(.Failure(Box(error))) })
@@ -231,7 +230,7 @@ public class API {
     public class func cancelRequest<T: Request>(requestType: T.Type, URLSession: NSURLSession, passingTest test: T -> Bool = { r in true }) {
         URLSession.getTasksWithCompletionHandler { dataTasks, uploadTasks, downloadTasks in
             let tasks = (dataTasks + uploadTasks + downloadTasks).filter { task in
-                if let request = (task as? NSURLSessionTask)?.request?.unbox as? T {
+                if let request = (task as? NSURLSessionTask)?.request as? T {
                     return test(request)
                 } else {
                     return false

--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -32,12 +32,12 @@ private var dataTaskCompletionHandlerKey = 0
 
 extension NSURLSessionTask {
     public override class func initialize() {
-        let dataTask: AnyObject = NSURLSession.sharedSession().dataTaskWithRequest(NSURLRequest())
-        let downloadTask: AnyObject = NSURLSession.sharedSession().downloadTaskWithRequest(NSURLRequest())
-        let uploadTask: AnyObject = NSURLSession.sharedSession().uploadTaskWithRequest(NSURLRequest(), fromData: NSData())
+        let dataTask = NSURLSession.sharedSession().dataTaskWithRequest(NSURLRequest())
+        let downloadTask = NSURLSession.sharedSession().downloadTaskWithRequest(NSURLRequest())
+        let uploadTask = NSURLSession.sharedSession().uploadTaskWithRequest(NSURLRequest(), fromData: NSData())
         
-        // On iOS 7 and Mac OS 10.9, `dataTask is NSURLSessionTask` returns false
-        if !(dataTask is NSURLSessionTask) {
+        // On iOS 7 and Mac OS 10.9, `(dataTask as AnyObject) is NSURLSessionTask` returns false
+        if !((dataTask as AnyObject) is NSURLSessionTask) {
             func bindClass(concreteClass: AnyClass, withClass abstractClass: AnyClass) {
                 let method = class_getInstanceMethod(concreteClass, "isKindOfClass:")
                 let block: @objc_block (AnyObject, AnyClass) -> Bool = { object, targetClass in

--- a/APIKitTests/APITests.swift
+++ b/APIKitTests/APITests.swift
@@ -159,4 +159,51 @@ class APITests: XCTestCase {
         
         waitForExpectationsWithTimeout(1.0, handler: nil)
     }
+    
+    // MARK: cancelling
+    func testFailureByCanceling() {
+        let expectation = expectationWithDescription("wait for response")
+        let request = MockAPI.Endpoint.Get()
+        
+        MockAPI.sendRequest(request) { response in
+            switch response {
+            case .Success:
+                XCTFail()
+                
+            case .Failure(let box):
+                let error = box.unbox
+                assert(error.domain, ==, NSURLErrorDomain)
+                assertEqual(error.code, NSURLErrorCancelled)
+            }
+            
+            expectation.fulfill()
+        }
+        
+        MockAPI.cancelRequest(MockAPI.Endpoint.Get.self)
+        
+        waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
+    
+    func testSuccessIfCancelingTestReturnsFalse() {
+        let expectation = expectationWithDescription("wait for response")
+        let request = MockAPI.Endpoint.Get()
+        
+        MockAPI.sendRequest(request) { response in
+            switch response {
+            case .Success:
+                break
+                
+            case .Failure(let box):
+                XCTFail()
+            }
+            
+            expectation.fulfill()
+        }
+        
+        MockAPI.cancelRequest(MockAPI.Endpoint.Get.self) { request in
+            return false
+        }
+        
+        waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
 }

--- a/APIKitTests/APITests.swift
+++ b/APIKitTests/APITests.swift
@@ -166,7 +166,8 @@ class APITests: XCTestCase {
             return true
         }, withStubResponse: { request in
             let response = OHHTTPStubsResponse(data: NSData(), statusCode: 200, headers: nil)
-            response.requestTime = 1.0
+            response.requestTime = 0.1
+            response.responseTime = 0.1
             return response
         })
         
@@ -199,6 +200,7 @@ class APITests: XCTestCase {
             let data = NSJSONSerialization.dataWithJSONObject([:], options: nil, error: nil)!
             let response = OHHTTPStubsResponse(data: data, statusCode: 200, headers: nil)
             response.requestTime = 0.1
+            response.responseTime = 0.1
             return response
         })
         

--- a/APIKitTests/APITests.swift
+++ b/APIKitTests/APITests.swift
@@ -162,6 +162,14 @@ class APITests: XCTestCase {
     
     // MARK: cancelling
     func testFailureByCanceling() {
+        OHHTTPStubs.stubRequestsPassingTest({ request in
+            return true
+        }, withStubResponse: { request in
+            let response = OHHTTPStubsResponse(data: NSData(), statusCode: 200, headers: nil)
+            response.requestTime = 1.0
+            return response
+        })
+        
         let expectation = expectationWithDescription("wait for response")
         let request = MockAPI.Endpoint.Get()
         
@@ -185,6 +193,15 @@ class APITests: XCTestCase {
     }
     
     func testSuccessIfCancelingTestReturnsFalse() {
+        OHHTTPStubs.stubRequestsPassingTest({ request in
+            return true
+        }, withStubResponse: { request in
+            let data = NSJSONSerialization.dataWithJSONObject([:], options: nil, error: nil)!
+            let response = OHHTTPStubsResponse(data: data, statusCode: 200, headers: nil)
+            response.requestTime = 0.1
+            return response
+        })
+        
         let expectation = expectationWithDescription("wait for response")
         let request = MockAPI.Endpoint.Get()
         

--- a/README.md
+++ b/README.md
@@ -139,6 +139,36 @@ class GitHub: API {
 }
 ```
 
+### Sending request
+
+```swift
+let request = GitHub.Endpoint.SearchRepositories(query: "APIKit", sort: .Stars)
+
+GitHub.sendRequest(request) { response in
+    switch response {
+    case .Success(let box):
+        // type of `box.unbox` is `[Repository]` (model object)
+        
+    case .Failure(let box):
+        // type of `box.unbox` is `NSError`
+    }
+}
+```
+
+### Canceling request
+
+```swift
+GitHub.cancelRequest(GitHub.Endpoint.SearchRepositories.self)
+```
+
+If you want to filter requests to be cancelled, add closure that identifies the request shoule be cancelled or not.
+
+```swift
+GitHub.cancelRequest(GitHub.Endpoint.SearchRepositories.self) { request in
+    return request.query == "APIKit"
+}
+```
+
 ## Advanced usage
 
 ### Creating NSError from response object

--- a/README.md
+++ b/README.md
@@ -212,8 +212,9 @@ This can add following features:
 
 NOTE: `URLSessionDelegate` also implements delegate methods of `NSURLSession` to implement wrapper of `NSURLSession`, so you should call super if you override following methods.
 
-- `func URLSession(session:task:didCompleteWithError:)`
-- `func URLSession(session:dataTask:didReceiveData:)`
+- `func URLSession(_:task:didCompleteWithError:)`
+- `func URLSession(_:dataTask:didReceiveData:)`
+- `func URLSession(_:dataTask:didBecomeDownloadTask:)`
 
 
 ## License


### PR DESCRIPTION
- Add `cancelRequest(_:passingTest:)`.
- Add `cancelRequest(_:URLSession:passingTest:)` to cancel requests in a specific URL session.

On iOS 7 and Mac OS 10.9, the actual objects created by `dataTaskWithRequest:` returns `false` for `task is NSURLSessionTask`. It causes failure of casting task to `NSURLSessionTask`, so getting `request` from task `(task as? NSURLSessionTask)?.request` always fails. To avoid this, implementation of `isKindOfClass:` for following classes are modified.

- `__NSCFLocalSessionDataTask`
- `__NSCFLocalSessionDownloadTask`
- `__NSCFLocalSessionUploadTask`

Because they are private classes, sample instances of them are created once in `initialize()` to access them.