### PR TITLE
Change `Request.responseFromObject` to class func

### DIFF
--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -86,7 +86,7 @@ public class API {
             task.request = request
             task.completionHandler = { data, URLResponse, connectionError in
                 if let error = connectionError {
-                    dispatch_async(mainQueue, { handler(.Failure(Box(error))) })
+                    dispatch_async(mainQueue, { handler(failure(error)) })
                     return
                 }
                 

--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -104,7 +104,7 @@ public class API {
                 }
                 
                 let mappedResponse: Result<T.Response, NSError> = self.responseBodyParser().parseData(data).flatMap { rawResponse in
-                    if let response = request.responseFromObject(rawResponse) {
+                    if let response = T.responseFromObject(rawResponse) {
                         return success(response)
                     } else {
                         let userInfo = [NSLocalizedDescriptionKey: "failed to create model object from raw object."]

--- a/APIKit/Request.swift
+++ b/APIKit/Request.swift
@@ -5,5 +5,5 @@ public protocol Request {
     
     var URLRequest: NSURLRequest? { get }
     
-    func responseFromObject(object: AnyObject) -> Response?
+    class func responseFromObject(object: AnyObject) -> Response?
 }

--- a/APIKitTests/APITests.swift
+++ b/APIKitTests/APITests.swift
@@ -30,7 +30,7 @@ class APITests: XCTestCase {
                     return MockAPI.URLRequest(.GET, "/")
                 }
                 
-                func responseFromObject(object: AnyObject) -> Response? {
+                class func responseFromObject(object: AnyObject) -> Response? {
                     return object as? [String: AnyObject]
                 }
             }

--- a/APIKitTests/RequestBodyBuilderTests.swift
+++ b/APIKitTests/RequestBodyBuilderTests.swift
@@ -87,7 +87,7 @@ class RequestBodyBuilderTests: XCTestCase {
         let string = "foo"
         let expectedError = NSError()
         let builder = RequestBodyBuilder.Custom(contentTypeHeader: "", buildBodyFromObject: { object in
-            return Result.Failure(Box(expectedError))
+            return failure(expectedError)
         })
 
         switch builder.buildBodyFromObject(string) {

--- a/APIKitTests/ResponseBodyParserTests.swift
+++ b/APIKitTests/ResponseBodyParserTests.swift
@@ -91,7 +91,7 @@ class ResponseBodyParserTests: XCTestCase {
         let expectedError = NSError()
         let data = NSData()
         let parser = ResponseBodyParser.Custom(acceptHeader: "", parseData: { data in
-            return Result.Failure(Box(expectedError))
+            return failure(expectedError)
         })
 
         switch parser.parseData(data) {

--- a/DemoApp/GitHub.swift
+++ b/DemoApp/GitHub.swift
@@ -45,7 +45,7 @@ class GitHub: API {
                 self.order = order
             }
 
-            func responseFromObject(object: AnyObject) -> Response? {
+            class func responseFromObject(object: AnyObject) -> Response? {
                 var repositories = [Repository]()
 
                 if let dictionaries = object["items"] as? [NSDictionary] {
@@ -89,7 +89,7 @@ class GitHub: API {
                 self.order = order
             }
 
-            func responseFromObject(object: AnyObject) -> Response? {
+            class func responseFromObject(object: AnyObject) -> Response? {
                 var users = [User]()
 
                 if let dictionaries = object["items"] as? [NSDictionary] {


### PR DESCRIPTION
This is a breaking change. Is there any specific needs of per request response building?

Additionally, the request parameter of `sendRequest` is not captured in a task's completion handler any more.
