### PR TITLE
Explicit request boxing for Tasks

### DIFF
--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -83,7 +83,7 @@ public class API {
         if let URLRequest = request.URLRequest {
             let task = URLSession.dataTaskWithRequest(URLRequest)
             
-            task.request = request
+            task.request = Box(request)
             task.completionHandler = { data, URLResponse, connectionError in
                 if let error = connectionError {
                     dispatch_async(mainQueue, { handler(.Failure(Box(error))) })
@@ -138,10 +138,10 @@ public class API {
                 var request: T?
                 switch task {
                 case let x as NSURLSessionDataTask:
-                    request = x.request as? T
+                    request = x.request?.unbox as? T
                     
                 case let x as NSURLSessionDownloadTask:
-                    request = x.request as? T
+                    request = x.request?.unbox as? T
                     
                 default:
                     break
@@ -194,14 +194,14 @@ private var dataTaskCompletionHandlerKey = 0
 private extension NSURLSessionDataTask {
     // `var request: Request?` is not available in both of Swift 1.1 and 1.2
     // ("protocol can only be used as a generic constraint")
-    private var request: Any? {
+    private var request: Box<Any>? {
         get {
-            return (objc_getAssociatedObject(self, &taskRequestKey) as? Box<Any>)?.unbox
+            return objc_getAssociatedObject(self, &taskRequestKey) as? Box<Any>
         }
         
         set {
             if let value = newValue {
-                objc_setAssociatedObject(self, &taskRequestKey, Box(value), UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+                objc_setAssociatedObject(self, &taskRequestKey, value, UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
             } else {
                 objc_setAssociatedObject(self, &taskRequestKey, nil, UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
             }
@@ -234,14 +234,14 @@ private extension NSURLSessionDataTask {
 }
 
 extension NSURLSessionDownloadTask {
-    private var request: Any? {
+    private var request: Box<Any>? {
         get {
-            return (objc_getAssociatedObject(self, &taskRequestKey) as? Box<Any>)?.unbox
+            return objc_getAssociatedObject(self, &taskRequestKey) as? Box<Any>
         }
         
         set {
             if let value = newValue {
-                objc_setAssociatedObject(self, &taskRequestKey, Box(value), UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+                objc_setAssociatedObject(self, &taskRequestKey, value, UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
             } else {
                 objc_setAssociatedObject(self, &taskRequestKey, nil, UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
             }


### PR DESCRIPTION
Because we are passing a request between a download task and a data task, we should avoid unnecessary boxing which is implicitly applied.