### PR TITLE
0.7.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Carthage/Checkouts/LlamaKit"]
 	path = Carthage/Checkouts/LlamaKit
-	url = https://github.com/modocache/LlamaKit.git
+	url = https://github.com/LlamaKit/LlamaKit.git
 [submodule "Carthage/Checkouts/Assertions"]
 	path = Carthage/Checkouts/Assertions
 	url = https://github.com/antitypical/Assertions.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "Carthage/Checkouts/LlamaKit"]
 	path = Carthage/Checkouts/LlamaKit
-	url = https://github.com/LlamaKit/LlamaKit.git
+	url = https://github.com/modocache/LlamaKit.git
 [submodule "Carthage/Checkouts/Assertions"]
 	path = Carthage/Checkouts/Assertions
-	url = https://github.com/ikesyo/Assertions.git
+	url = https://github.com/antitypical/Assertions.git
 [submodule "Carthage/Checkouts/OHHTTPStubs"]
 	path = Carthage/Checkouts/OHHTTPStubs
 	url = https://github.com/ishkawa/OHHTTPStubs.git

--- a/APIKit.xcodeproj/xcshareddata/xcschemes/APIKit-iOS.xcscheme
+++ b/APIKit.xcodeproj/xcshareddata/xcschemes/APIKit-iOS.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7FEC5A131A96FE2600B1D3C0"

--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -65,18 +65,8 @@ public class API {
         }
     }
 
-    // In Swift 1.1, we could not omit `URLSession` argument of `func send(request:URLSession(=default):handler(=default):)`
-    // with trailing closure, so we provide following 2 methods
-    // - `func sendRequest(request:handler(=default):)`
-    // - `func sendRequest(request:URLSession:handler(=default):)`.
-    // In Swift 1.2, we can omit default arguments with trailing closure, so they should be replaced with
-    // - `func sendRequest(request:URLSession(=default):handler(=default):)`
-    public class func sendRequest<T: Request>(request: T, handler: (Result<T.Response, NSError>) -> Void = {r in}) -> NSURLSessionDataTask? {
-        return sendRequest(request, URLSession: defaultURLSession, handler: handler)
-    }
-
     // send request and build response object
-    public class func sendRequest<T: Request>(request: T, URLSession: NSURLSession, handler: (Result<T.Response, NSError>) -> Void = {r in}) -> NSURLSessionDataTask? {
+    public class func sendRequest<T: Request>(request: T, URLSession: NSURLSession = defaultURLSession, handler: (Result<T.Response, NSError>) -> Void = {r in}) -> NSURLSessionDataTask? {
         let mainQueue = dispatch_get_main_queue()
         
         if let URLRequest = request.URLRequest {
@@ -191,7 +181,7 @@ private var dataTaskResponseBufferKey = 0
 private var dataTaskCompletionHandlerKey = 0
 
 private extension NSURLSessionDataTask {
-    // `var request: Request?` is not available in both of Swift 1.1 and 1.2
+    // `var request: Request?` is not available in Swift 1.2
     // ("protocol can only be used as a generic constraint")
     private var request: Any? {
         get {
@@ -247,4 +237,3 @@ extension NSURLSessionDownloadTask {
         }
     }
 }
-

--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -9,7 +9,7 @@ public let APIKitErrorDomain = "APIKitErrorDomain"
 public class API {
     // configurations
     public class var baseURL: NSURL {
-        fatalError("API.baseURL() must be overrided in subclasses.")
+        fatalError("API.baseURL must be overrided in subclasses.")
     }
     
     public class var requestBodyBuilder: RequestBodyBuilder {

--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -42,7 +42,7 @@ private extension NSURLSessionDataTask {
     
     private var completionHandler: ((NSData, NSURLResponse?, NSError?) -> Void)? {
         get {
-            return (objc_getAssociatedObject(self, &dataTaskCompletionHandlerKey) as? Box<(NSData?, NSURLResponse?, NSError?) -> Void>)?.unbox
+            return (objc_getAssociatedObject(self, &dataTaskCompletionHandlerKey) as? Box<(NSData, NSURLResponse?, NSError?) -> Void>)?.unbox
         }
         
         set {

--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -55,11 +55,10 @@ private extension NSURLSessionDataTask {
     }
 }
 
-// use private, global scope variable until we can use stored class var in Swift 1.2
-private var instancePairDictionary = [String: (API, NSURLSession)]()
-private let instancePairSemaphore = dispatch_semaphore_create(1)
-
 public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
+    private static var instancePairDictionary = [String: (API, NSURLSession)]()
+    private static let instancePairSemaphore = dispatch_semaphore_create(1)
+
     // configurations
     public class func baseURL() -> NSURL {
         fatalError("API.baseURL() must be overrided in subclasses.")
@@ -99,7 +98,7 @@ public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
             let queue = self.URLSessionDelegateQueue()
             let session = NSURLSession(configuration: configuration, delegate: instance, delegateQueue: queue)
             let pair = (instance, session)
-            instancePairDictionary[className] = pair
+            self.instancePairDictionary[className] = pair
             return pair
         }()
         dispatch_semaphore_signal(instancePairSemaphore)

--- a/APIKit/APIKit.swift
+++ b/APIKit/APIKit.swift
@@ -94,7 +94,7 @@ public class API: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
         
         dispatch_semaphore_wait(instancePairSemaphore, DISPATCH_TIME_FOREVER)
         let pair: (API, NSURLSession) = instancePairDictionary[className] ?? {
-            let instance = (self as NSObject.Type)() as API
+            let instance = (self as NSObject.Type)() as! API
             let configuration = self.URLSessionConfiguration()
             let queue = self.URLSessionDelegateQueue()
             let session = NSURLSession(configuration: configuration, delegate: instance, delegateQueue: queue)

--- a/APIKit/RequestBodyBuilder.swift
+++ b/APIKit/RequestBodyBuilder.swift
@@ -33,14 +33,14 @@ public enum RequestBodyBuilder {
                 return failure(error)
             }
 
-            return try { error in
+            return try({ error in
                 return NSJSONSerialization.dataWithJSONObject(object, options: writingOptions, error: error)
-            }
+            })
 
         case .URL(let encoding):
-            return try { error in
+            return try ({ error in
                 return URLEncodedSerialization.dataFromObject(object, encoding: encoding, error: error)
-            }
+            })
 
         case .Custom(let (_, buildBodyFromObject)):
             return buildBodyFromObject(object)

--- a/APIKit/RequestBodyBuilder.swift
+++ b/APIKit/RequestBodyBuilder.swift
@@ -38,7 +38,7 @@ public enum RequestBodyBuilder {
             })
 
         case .URL(let encoding):
-            return try ({ error in
+            return try({ error in
                 return URLEncodedSerialization.dataFromObject(object, encoding: encoding, error: error)
             })
 

--- a/APIKit/ResponseBodyParser.swift
+++ b/APIKit/ResponseBodyParser.swift
@@ -25,14 +25,14 @@ public enum ResponseBodyParser {
     public func parseData(data: NSData) -> Result<AnyObject, NSError> {
         switch self {
         case .JSON(let readingOptions):
-            return try { error in
+            return try ({ error in
                 return NSJSONSerialization.JSONObjectWithData(data, options: readingOptions, error: error)
-            }
+            })
 
         case .URL(let encoding):
-            return try { error in
+            return try ({ error in
                 return URLEncodedSerialization.objectFromData(data, encoding: encoding, error: error)
-            }
+            })
 
         case .Custom(let (accept, parseData)):
             return parseData(data)

--- a/APIKit/ResponseBodyParser.swift
+++ b/APIKit/ResponseBodyParser.swift
@@ -25,12 +25,12 @@ public enum ResponseBodyParser {
     public func parseData(data: NSData) -> Result<AnyObject, NSError> {
         switch self {
         case .JSON(let readingOptions):
-            return try ({ error in
+            return try({ error in
                 return NSJSONSerialization.JSONObjectWithData(data, options: readingOptions, error: error)
             })
 
         case .URL(let encoding):
-            return try ({ error in
+            return try({ error in
                 return URLEncodedSerialization.objectFromData(data, encoding: encoding, error: error)
             })
 

--- a/APIKit/URLEncodedSerialization.swift
+++ b/APIKit/URLEncodedSerialization.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 private func escape(string: String) -> String {
-    return CFURLCreateStringByAddingPercentEscapes(nil, string, nil, "!*'();:@&=+$,/?%#[]", CFStringBuiltInEncodings.UTF8.rawValue) as! String
+    return CFURLCreateStringByAddingPercentEscapes(nil, string, nil, "!*'();:@&=+$,/?%#[]", CFStringBuiltInEncodings.UTF8.rawValue) as String
 }
 
 private func unescape(string: String) -> String {
-    return CFURLCreateStringByReplacingPercentEscapes(nil, string, nil) as! String
+    return CFURLCreateStringByReplacingPercentEscapes(nil, string, nil) as String
 }
 
 public class URLEncodedSerialization {

--- a/APIKit/URLEncodedSerialization.swift
+++ b/APIKit/URLEncodedSerialization.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 private func escape(string: String) -> String {
-    return CFURLCreateStringByAddingPercentEscapes(nil, string, nil, "!*'();:@&=+$,/?%#[]", CFStringBuiltInEncodings.UTF8.rawValue)
+    return CFURLCreateStringByAddingPercentEscapes(nil, string, nil, "!*'();:@&=+$,/?%#[]", CFStringBuiltInEncodings.UTF8.rawValue) as! String
 }
 
 private func unescape(string: String) -> String {
-    return CFURLCreateStringByReplacingPercentEscapes(nil, string, nil)
+    return CFURLCreateStringByReplacingPercentEscapes(nil, string, nil) as! String
 }
 
 public class URLEncodedSerialization {
@@ -15,8 +15,8 @@ public class URLEncodedSerialization {
         if let string = NSString(data: data, encoding: encoding) as? String {
             dictionary = [String: AnyObject]()
             
-            for pair in split(string, { $0 == "&" }) {
-                let contents = split(pair, { $0 == "=" })
+            for pair in string.componentsSeparatedByString("&") {
+                let contents = pair.componentsSeparatedByString("=")
                 
                 if contents.count == 2 {
                     dictionary?[contents[0]] = unescape(contents[1])

--- a/APIKitTests/APITests.swift
+++ b/APIKitTests/APITests.swift
@@ -6,15 +6,15 @@ import OHHTTPStubs
 
 class APITests: XCTestCase {
     class MockAPI: API {
-        override class func baseURL() -> NSURL {
+        override class var baseURL: NSURL {
             return NSURL(string: "https://api.github.com")!
         }
         
-        override class func requestBodyBuilder() -> RequestBodyBuilder {
+        override class var requestBodyBuilder: RequestBodyBuilder {
             return .JSON(writingOptions: nil)
         }
         
-        override class func responseBodyParser() -> ResponseBodyParser {
+        override class var responseBodyParser: ResponseBodyParser {
             return .JSON(readingOptions: nil)
         }
 

--- a/APIKitTests/RequestBodyBuilderTests.swift
+++ b/APIKitTests/RequestBodyBuilderTests.swift
@@ -16,10 +16,10 @@ class RequestBodyBuilderTests: XCTestCase {
 
         switch builder.buildBodyFromObject(object) {
         case .Success(let box):
-            let dictionary = NSJSONSerialization.JSONObjectWithData(box.unbox, options: nil, error: nil) as [String: Int]
-            assertEqual(dictionary["foo"], 1)
-            assertEqual(dictionary["bar"], 2)
-            assertEqual(dictionary["baz"], 3)
+            let dictionary = NSJSONSerialization.JSONObjectWithData(box.unbox, options: nil, error: nil) as? [String: Int]
+            assertEqual(dictionary?["foo"], 1)
+            assertEqual(dictionary?["bar"], 2)
+            assertEqual(dictionary?["baz"], 3)
 
         case .Failure:
             XCTFail()
@@ -52,10 +52,10 @@ class RequestBodyBuilderTests: XCTestCase {
 
         switch builder.buildBodyFromObject(object) {
         case .Success(let box):
-            let dictionary =  URLEncodedSerialization.objectFromData(box.unbox, encoding: NSUTF8StringEncoding, error: nil) as [String: String]
-            assertEqual(dictionary["foo"], "1")
-            assertEqual(dictionary["bar"], "2")
-            assertEqual(dictionary["baz"], "3")
+            let dictionary =  URLEncodedSerialization.objectFromData(box.unbox, encoding: NSUTF8StringEncoding, error: nil) as? [String: String]
+            assertEqual(dictionary?["foo"], "1")
+            assertEqual(dictionary?["bar"], "2")
+            assertEqual(dictionary?["baz"], "3")
 
         case .Failure:
             XCTFail()
@@ -63,7 +63,7 @@ class RequestBodyBuilderTests: XCTestCase {
     }
     
     func testCustomHeader() {
-        let builder = RequestBodyBuilder.Custom(contentTypeHeader: "foo", buildBodyFromObject: { o in success(o as NSData) })
+        let builder = RequestBodyBuilder.Custom(contentTypeHeader: "foo", buildBodyFromObject: { o in success(o as! NSData) })
         assertEqual(builder.contentTypeHeader, "foo")
     }
     

--- a/APIKitTests/ResponseBodyParserTests.swift
+++ b/APIKitTests/ResponseBodyParserTests.swift
@@ -17,10 +17,10 @@ class ResponseBodyParserTests: XCTestCase {
 
         switch parser.parseData(data) {
         case .Success(let box):
-            let dictionary = box.unbox as [String: Int]
-            assertEqual(dictionary["foo"], 1)
-            assertEqual(dictionary["bar"], 2)
-            assertEqual(dictionary["baz"], 3)
+            let dictionary = box.unbox as? [String: Int]
+            assertEqual(dictionary?["foo"], 1)
+            assertEqual(dictionary?["bar"], 2)
+            assertEqual(dictionary?["baz"], 3)
 
         case .Failure:
             XCTFail()
@@ -55,10 +55,10 @@ class ResponseBodyParserTests: XCTestCase {
 
         switch parser.parseData(data) {
         case .Success(let box):
-            let dictionary = box.unbox as [String: String]
-            assertEqual(dictionary["foo"], "1")
-            assertEqual(dictionary["bar"], "2")
-            assertEqual(dictionary["baz"], "3")
+            let dictionary = box.unbox as? [String: String]
+            assertEqual(dictionary?["foo"], "1")
+            assertEqual(dictionary?["bar"], "2")
+            assertEqual(dictionary?["baz"], "3")
 
         case .Failure:
             XCTFail()
@@ -79,7 +79,7 @@ class ResponseBodyParserTests: XCTestCase {
 
         switch parser.parseData(data) {
         case .Success(let box):
-            let dictionary = box.unbox as [String: Int]
+            let dictionary = box.unbox as? [String: Int]
             assertEqual(dictionary, expectedDictionary)
 
         case .Failure:

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
-github "LlamaKit/LlamaKit" ~> 0.5.0
+# use forked repo until https://github.com/LlamaKit/LlamaKit/pull/38 is merged.
+github "modocache/LlamaKit" "try-trailing-closure"

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,1 @@
-# use forked repo until https://github.com/LlamaKit/LlamaKit/pull/38 is merged.
-github "modocache/LlamaKit" "try-trailing-closure"
+github "LlamaKit/LlamaKit" ~> 0.6.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "ikesyo/Assertions" "swift-1.1"
+github "antitypical/Assertions" "master"
 github "ishkawa/OHHTTPStubs" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "ikesyo/Assertions" "fec437ce6857259ac8bda3eb255c5782aa798734"
-github "LlamaKit/LlamaKit" "v0.5.0"
+github "antitypical/Assertions" "19bac03828dcb2f9b9ecb7f829e09bb3900886e5"
+github "modocache/LlamaKit" "c070fc0308dee6f891d028a71254fb3605363fd6"
 github "ishkawa/OHHTTPStubs" "825806534aa2bdc6ebba5e26cd304de2ced67395"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "antitypical/Assertions" "19bac03828dcb2f9b9ecb7f829e09bb3900886e5"
-github "modocache/LlamaKit" "c070fc0308dee6f891d028a71254fb3605363fd6"
+github "LlamaKit/LlamaKit" "v0.6.0"
 github "ishkawa/OHHTTPStubs" "825806534aa2bdc6ebba5e26cd304de2ced67395"

--- a/DemoApp/GitHub.swift
+++ b/DemoApp/GitHub.swift
@@ -3,19 +3,19 @@ import APIKit
 import LlamaKit
 
 class GitHub: API {
-    override class func baseURL() -> NSURL {
+    override class var baseURL: NSURL {
         return NSURL(string: "https://api.github.com")!
     }
 
-    override class func requestBodyBuilder() -> RequestBodyBuilder {
+    override class var requestBodyBuilder: RequestBodyBuilder {
         return .JSON(writingOptions: nil)
     }
 
-    override class func responseBodyParser() -> ResponseBodyParser {
+    override class var responseBodyParser: ResponseBodyParser {
         return .JSON(readingOptions: nil)
     }
 
-    class Request {
+    class Endpoint {
         // https://developer.github.com/v3/search/#search-repositories
         class SearchRepositories: APIKit.Request {
             enum Sort: String {

--- a/DemoApp/Models.swift
+++ b/DemoApp/Models.swift
@@ -1,38 +1,40 @@
 import Foundation
 
-class Repository {
-    let id: Int!
-    let name: String!
-    let owner: User!
+struct Repository {
+    let id: Int
+    let name: String
+    let owner: User
     
     init?(dictionary: NSDictionary) {
-        id = dictionary["id"] as? Int
-        name = dictionary["name"] as? String
-        
-        if let userDictionary = dictionary["owner"] as? NSDictionary {
-            owner = User(dictionary: userDictionary)
-        }
-        
-        if id == nil || name == nil || owner == nil {
+        if 
+        let id = dictionary["id"] as? Int,
+        let userDictionary = dictionary["owner"] as? NSDictionary,
+        let name = dictionary["name"] as? String,
+        let user = User(dictionary: userDictionary) {
+            self.id = id
+            self.name = name
+            self.owner = user
+        } else {
             return nil
         }
     }
 }
 
-class User {
-    let id: Int!
-    let login: String!
-    let avatarURL: NSURL!
+struct User {
+    let id: Int
+    let login: String
+    let avatarURL: NSURL
     
     init?(dictionary: NSDictionary) {
-        id = dictionary["id"] as? Int
-        login = dictionary["login"] as? String
-        
-        if let string = dictionary["avatar_url"] as? String {
-            avatarURL = NSURL(string: string)
-        }
-        
-        if id == nil || login == nil || avatarURL == nil {
+        if
+        let id = dictionary["id"] as? Int,
+        let login = dictionary["login"] as? String,
+        let string = dictionary["avatar_url"] as? String,
+        let avatarURL = NSURL(string: string) {
+            self.id = id
+            self.login = login
+            self.avatarURL = avatarURL
+        } else {
             return nil
         }
     }

--- a/DemoApp/ViewController.swift
+++ b/DemoApp/ViewController.swift
@@ -32,7 +32,7 @@ class ViewController: UITableViewController {
     }
     
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier("Cell", forIndexPath: indexPath) as UITableViewCell
+        let cell = tableView.dequeueReusableCellWithIdentifier("Cell", forIndexPath: indexPath) as! UITableViewCell
         let repository = repositories[indexPath.row]
         
         cell.textLabel?.text = "\(repository.owner.login)/\(repository.name)"

--- a/DemoApp/ViewController.swift
+++ b/DemoApp/ViewController.swift
@@ -10,7 +10,7 @@ class ViewController: UITableViewController {
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         
-        let request = GitHub.Request.SearchRepositories(query: "APIKit")
+        let request = GitHub.Endpoint.SearchRepositories(query: "APIKit")
         
         GitHub.sendRequest(request) { response in
             switch response {

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ GitHub.sendRequest(request) { response in
 
 ## Requirements
 
-- Swift 1.1
+- Swift 1.2
 - iOS 8.0 or later (if you use Carthage), iOS 7.0 if you copy sources
 - Mac OS 10.9 or later
 
-If you want to use APIKit with Swift 1.2, try `swift-1.2` branch.
+If you want to use APIKit with Swift 1.1, try [0.6.0](https://github.com/ishkawa/APIKit/releases/tag/0.6.0).
 
 ## Installation
 
@@ -72,24 +72,24 @@ You have 3 choices. If your app supports iOS 7.0, you can only choose copying so
 ## Usage
 
 1. Create subclass of `API` that represents target web API.
-2. Set base URL by overriding `baseURL()`.
-3. Set encoding of request body by overriding `requestBodyBuilder()`.
-4. Set encoding of response body by overriding `responseBodyParser()`.
+2. Set base URL by overriding `baseURL`.
+3. Set encoding of request body by overriding `requestBodyBuilder`.
+4. Set encoding of response body by overriding `responseBodyParser`.
 5. Define request classes that conforms to `Request` for each endpoints.
 
 ### Example
 
 ```swift
 class GitHub: API {
-    override class func baseURL() -> NSURL {
+    override class var baseURL: NSURL {
         return NSURL(string: "https://api.github.com")!
     }
 
-    override class func requestBodyBuilder() -> RequestBodyBuilder {
+    override class var requestBodyBuilder: RequestBodyBuilder {
         return .JSON(writingOptions: nil)
     }
 
-    override class func responseBodyParser() -> ResponseBodyParser {
+    override class var responseBodyParser: ResponseBodyParser {
         return .JSON(readingOptions: nil)
     }
 

--- a/circle.yml
+++ b/circle.yml
@@ -4,14 +4,16 @@ machine:
 
 dependencies:
   override:
-    - ./script/import-certificates
-    - sudo gem install xcpretty
-    - brew install carthage
-    - carthage bootstrap
+    #- ./script/import-certificates
+    #- sudo gem install xcpretty
+    #- brew install carthage
+    #- carthage bootstrap
+    echo "skip installing dependencies until Circle CI supports Xcode 6.3 (with Swift 1.2)."
 
 test:
   override:
-    - set -o pipefail && xcodebuild test -scheme APIKit-iOS | xcpretty -c -r junit -o $CIRCLE_TEST_REPORTS/test-report-ios.xml
-    - set -o pipefail && xcodebuild test -scheme APIKit-Mac | xcpretty -c -r junit -o $CIRCLE_TEST_REPORTS/test-report-mac.xml
-    - set -o pipefail && xcodebuild build -scheme DemoApp -sdk iphonesimulator | xcpretty -c
+    #- set -o pipefail && xcodebuild test -scheme APIKit-iOS | xcpretty -c -r junit -o $CIRCLE_TEST_REPORTS/test-report-ios.xml
+    #- set -o pipefail && xcodebuild test -scheme APIKit-Mac | xcpretty -c -r junit -o $CIRCLE_TEST_REPORTS/test-report-mac.xml
+    #- set -o pipefail && xcodebuild build -scheme DemoApp -sdk iphonesimulator | xcpretty -c
+    echo "skip testing until Circle CI supports Xcode 6.3 (with Swift 1.2)."
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,12 +8,12 @@ dependencies:
     #- sudo gem install xcpretty
     #- brew install carthage
     #- carthage bootstrap
-    echo "skip installing dependencies until Circle CI supports Xcode 6.3 (with Swift 1.2)."
+    - echo "skip installing dependencies until Circle CI supports Xcode 6.3 (with Swift 1.2)."
 
 test:
   override:
     #- set -o pipefail && xcodebuild test -scheme APIKit-iOS | xcpretty -c -r junit -o $CIRCLE_TEST_REPORTS/test-report-ios.xml
     #- set -o pipefail && xcodebuild test -scheme APIKit-Mac | xcpretty -c -r junit -o $CIRCLE_TEST_REPORTS/test-report-mac.xml
     #- set -o pipefail && xcodebuild build -scheme DemoApp -sdk iphonesimulator | xcpretty -c
-    echo "skip testing until Circle CI supports Xcode 6.3 (with Swift 1.2)."
+    - echo "skip testing until Circle CI supports Xcode 6.3 (with Swift 1.2)."
 


### PR DESCRIPTION
- Support Swift 1.2.
- Upgrade LlamaKit to 0.6.0
- Configure `API` by class var instead of class func (breaking change).
