### PR TITLE
Specify Release configuration for test build

### DIFF
--- a/APIKit.xcodeproj/xcshareddata/xcschemes/APIKit-Mac.xcscheme
+++ b/APIKit.xcodeproj/xcshareddata/xcschemes/APIKit-Mac.xcscheme
@@ -54,7 +54,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">

--- a/APIKit.xcodeproj/xcshareddata/xcschemes/APIKit-iOS.xcscheme
+++ b/APIKit.xcodeproj/xcshareddata/xcschemes/APIKit-iOS.xcscheme
@@ -40,7 +40,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Release">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
To detect issues caused by the compiler optimization. Both iOS and Mac tests are passing on my Machine.