### PR TITLE
Remove unnecessary overriding

### DIFF
--- a/APIKitTests/APITests.swift
+++ b/APIKitTests/APITests.swift
@@ -10,14 +10,6 @@ class APITests: XCTestCase {
             return NSURL(string: "https://api.github.com")!
         }
         
-        override class var requestBodyBuilder: RequestBodyBuilder {
-            return .JSON(writingOptions: nil)
-        }
-        
-        override class var responseBodyParser: ResponseBodyParser {
-            return .JSON(readingOptions: nil)
-        }
-
         override class func responseErrorFromObject(object: AnyObject) -> NSError {
             return NSError(domain: "MockAPIErrorDomain", code: 10000, userInfo: nil)
         }

--- a/DemoApp/GitHub.swift
+++ b/DemoApp/GitHub.swift
@@ -7,14 +7,6 @@ class GitHub: API {
         return NSURL(string: "https://api.github.com")!
     }
 
-    override class var requestBodyBuilder: RequestBodyBuilder {
-        return .JSON(writingOptions: nil)
-    }
-
-    override class var responseBodyParser: ResponseBodyParser {
-        return .JSON(readingOptions: nil)
-    }
-
     class Endpoint {
         // https://developer.github.com/v3/search/#search-repositories
         class SearchRepositories: APIKit.Request {


### PR DESCRIPTION
These are not needed anymore in Swift 1.2, they can be compiled now.