### PR TITLE
Switch to original OHHTTPStubs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/antitypical/Assertions.git
 [submodule "Carthage/Checkouts/OHHTTPStubs"]
 	path = Carthage/Checkouts/OHHTTPStubs
-	url = https://github.com/ishkawa/OHHTTPStubs.git
+	url = https://github.com/AliSoftware/OHHTTPStubs.git

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
 github "antitypical/Assertions" "master"
-github "ishkawa/OHHTTPStubs" "master"
+github "AliSoftware/OHHTTPStubs" ~> 4.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "antitypical/Assertions" "19bac03828dcb2f9b9ecb7f829e09bb3900886e5"
 github "LlamaKit/LlamaKit" "v0.6.0"
-github "ishkawa/OHHTTPStubs" "825806534aa2bdc6ebba5e26cd304de2ced67395"
+github "AliSoftware/OHHTTPStubs" "4.0.0"


### PR DESCRIPTION
[4.0.0](https://github.com/AliSoftware/OHHTTPStubs/blob/b5742078af2032c93f51c6dd47f401d89bf2cc23/CHANGELOG.md#400--improvements-for-swift) was released with Carthage support (from 3.1.11) and some improvements for Swift.