### PR TITLE
Add custom requestBodyBuilder argument to URLRequest

### DIFF
--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -35,7 +35,7 @@ public class API {
     )
 
     // build NSURLRequest
-    public class func URLRequest(method: Method, _ path: String, _ parameters: [String: AnyObject] = [:]) -> NSURLRequest? {
+    public class func URLRequest(method: Method, _ path: String, _ parameters: [String: AnyObject] = [:], requestBodyBuilder: RequestBodyBuilder = requestBodyBuilder) -> NSURLRequest? {
         if let components = NSURLComponents(URL: baseURL, resolvingAgainstBaseURL: true) {
             let request = NSMutableURLRequest()
             


### PR DESCRIPTION
Sometimes want to set a custom requestBodyBuilder for individual endpoint.
So use API requestBodyBuilder as a default and add a parameter to specify custom requestBodyBuilder.