### PR TITLE
Deprecate `URLRequest` with implicit parameter labels

### DIFF
--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -35,7 +35,7 @@ public class API {
     )
 
     // build NSURLRequest
-    public class func URLRequest(method: Method, _ path: String, _ parameters: [String: AnyObject] = [:], requestBodyBuilder: RequestBodyBuilder = requestBodyBuilder) -> NSURLRequest? {
+    public class func URLRequest(#method: Method, path: String, parameters: [String: AnyObject] = [:], requestBodyBuilder: RequestBodyBuilder = requestBodyBuilder) -> NSURLRequest? {
         if let components = NSURLComponents(URL: baseURL, resolvingAgainstBaseURL: true) {
             let request = NSMutableURLRequest()
             
@@ -63,6 +63,11 @@ public class API {
         } else {
             return nil
         }
+    }
+    
+    @availability(*, unavailable, renamed="URLRequest(method:path:parameters:requestBodyBuilder)")
+    public class func URLRequest(method: Method, _ path: String, _ parameters: [String: AnyObject] = [:], requestBodyBuilder: RequestBodyBuilder = requestBodyBuilder) -> NSURLRequest? {
+        return URLRequest(method: method, path: path, parameters: parameters, requestBodyBuilder: requestBodyBuilder)
     }
 
     // send request and build response object

--- a/APIKitTests/APITests.swift
+++ b/APIKitTests/APITests.swift
@@ -19,7 +19,7 @@ class APITests: XCTestCase {
                 typealias Response = [String: AnyObject]
                 
                 var URLRequest: NSURLRequest? {
-                    return MockAPI.URLRequest(.GET, "/")
+                    return MockAPI.URLRequest(method: .GET, path: "/")
                 }
                 
                 class func responseFromObject(object: AnyObject) -> Response? {

--- a/DemoApp/GitHub.swift
+++ b/DemoApp/GitHub.swift
@@ -28,7 +28,11 @@ class GitHub: API {
             let order: Order
 
             var URLRequest: NSURLRequest? {
-                return GitHub.URLRequest(.GET, "/search/repositories", ["q": query, "sort": sort.rawValue, "order": order.rawValue])
+                return GitHub.URLRequest(
+                    method: .GET,
+                    path: "/search/repositories",
+                    parameters: ["q": query, "sort": sort.rawValue, "order": order.rawValue]
+                )
             }
 
             init(query: String, sort: Sort = .Stars, order: Order = .Ascending) {
@@ -72,7 +76,11 @@ class GitHub: API {
             let order: Order
 
             var URLRequest: NSURLRequest? {
-                return GitHub.URLRequest(.GET, "/search/users", ["q": query, "sort": sort.rawValue, "order": order.rawValue])
+                return GitHub.URLRequest(
+                    method: .GET,
+                    path: "/search/users",
+                    parameters: ["q": query, "sort": sort.rawValue, "order": order.rawValue]
+                )
             }
 
             init(query: String, sort: Sort = .Followers, order: Order = .Ascending) {

--- a/README.md
+++ b/README.md
@@ -114,7 +114,11 @@ class GitHub: API {
             let order: Order
 
             var URLRequest: NSURLRequest? {
-                return GitHub.URLRequest(.GET, "/search/repositories", ["q": query, "sort": sort.rawValue, "order": order.rawValue])
+                return GitHub.URLRequest(
+                    method: .GET,
+                    path: "/search/repositories",
+                    parameters: ["q": query, "sort": sort.rawValue, "order": order.rawValue]
+                )
             }
 
             init(query: String, sort: Sort = .Stars, order: Order = .Ascending) {


### PR DESCRIPTION
I wrote `func URLRequest(_:_:_:)` in early version of APIKit to make code shorter, but this sacrifices readability and flexibility of argument. So I suggest to deprecate this method and add `func URLRequest(method:path:parameters:requestBodyBuilder:)`.

#### Old
```swift
var URLRequest: NSURLRequest? {
    return GitHub.URLRequest(.GET, "/search/repositories", ["q": query, "sort": sort.rawValue, "order": order.rawValue])
}
```

#### New
```swift
var URLRequest: NSURLRequest? {
    return GitHub.URLRequest(
        method: .GET,
        path: "/search/repositories",
        parameters: ["q": query, "sort": sort.rawValue, "order": order.rawValue]
    )
}
```

In new method, we can skip `parameter` argument like below. This can be useful to set ad hoc `requestBodyBuilder` for a specific endpoint (added in #31).

```swift
var URLRequest: NSURLRequest? {
    return MyAPI.URLRequest(
        method: .POST,
        path: "/profile/image",
        requestBodyBuilder: RequestBodyBuilder.Custom(
            contentTypeHeader: "multipart/form-data, boundary=abcd",
            buildBodyFromObject: { image in
                let data = NSMutableData()
                // ... write http body to data
                return data
            }
        )
    )
}
```