### PR TITLE
Avoid parsing when status is 204.

### DIFF
--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -96,31 +96,17 @@ public class API {
                     return
                 }
                 
-                if statusCode == 204 {
-                    let noContentResponse: Result<T.Response, NSError> = {
-                        if let response = T.responseFromObject([:]) {
-                            return .success(response)
-                        } else {
-                            let userInfo = [NSLocalizedDescriptionKey: "failed to create no content response."]
-                            let error = NSError(domain: APIKitErrorDomain, code: 0, userInfo: userInfo)
-                            return .failure(error)
-                        }
-                    }()
-                    dispatch_async(mainQueue) { handler(noContentResponse) }
-                } else {
-                    let mappedResponse: Result<T.Response, NSError> = self.responseBodyParser.parseData(data).flatMap { rawResponse in
-                        if let response = T.responseFromObject(rawResponse) {
-                            return .success(response)
-                        } else {
-                            let userInfo = [NSLocalizedDescriptionKey: "failed to create model object from raw object."]
-                            let error = NSError(domain: APIKitErrorDomain, code: 0, userInfo: userInfo)
-                            return .failure(error)
-                        }
+                let mappedResponse: Result<T.Response, NSError> = self.responseBodyParser.parseData(data).flatMap { rawResponse in
+                    if let response = T.responseFromObject(rawResponse) {
+                        return .success(response)
+                    } else {
+                        let userInfo = [NSLocalizedDescriptionKey: "failed to create model object from raw object."]
+                        let error = NSError(domain: APIKitErrorDomain, code: 0, userInfo: userInfo)
+                        return .failure(error)
                     }
-                    
-                    dispatch_async(mainQueue) { handler(mappedResponse) }
                 }
-
+                
+                dispatch_async(mainQueue) { handler(mappedResponse) }
             }
             
             task.resume()

--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -96,17 +96,31 @@ public class API {
                     return
                 }
                 
-                let mappedResponse: Result<T.Response, NSError> = self.responseBodyParser.parseData(data).flatMap { rawResponse in
-                    if let response = T.responseFromObject(rawResponse) {
-                        return .success(response)
-                    } else {
-                        let userInfo = [NSLocalizedDescriptionKey: "failed to create model object from raw object."]
-                        let error = NSError(domain: APIKitErrorDomain, code: 0, userInfo: userInfo)
-                        return .failure(error)
+                if statusCode == 204 {
+                    let noContentResponse: Result<T.Response, NSError> = {
+                        if let response = T.responseFromObject([:]) {
+                            return .success(response)
+                        } else {
+                            let userInfo = [NSLocalizedDescriptionKey: "failed to create no content response."]
+                            let error = NSError(domain: APIKitErrorDomain, code: 0, userInfo: userInfo)
+                            return .failure(error)
+                        }
+                    }()
+                    dispatch_async(mainQueue) { handler(noContentResponse) }
+                } else {
+                    let mappedResponse: Result<T.Response, NSError> = self.responseBodyParser.parseData(data).flatMap { rawResponse in
+                        if let response = T.responseFromObject(rawResponse) {
+                            return .success(response)
+                        } else {
+                            let userInfo = [NSLocalizedDescriptionKey: "failed to create model object from raw object."]
+                            let error = NSError(domain: APIKitErrorDomain, code: 0, userInfo: userInfo)
+                            return .failure(error)
+                        }
                     }
+                    
+                    dispatch_async(mainQueue) { handler(mappedResponse) }
                 }
 
-                dispatch_async(mainQueue) { handler(mappedResponse) }
             }
             
             task.resume()

--- a/APIKit/ResponseBodyParser.swift
+++ b/APIKit/ResponseBodyParser.swift
@@ -25,6 +25,9 @@ public enum ResponseBodyParser {
     public func parseData(data: NSData) -> Result<AnyObject, NSError> {
         switch self {
         case .JSON(let readingOptions):
+            if data.length == 0 {
+                return .success([:])
+            }
             return try { error in
                 return NSJSONSerialization.JSONObjectWithData(data, options: readingOptions, error: error)
             }

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "antitypical/Assertions" "1.1"
 github "robrix/Box" "1.2.2"
-github "AliSoftware/OHHTTPStubs" "4.0.1"
-github "antitypical/Result" "0.4.1"
+github "AliSoftware/OHHTTPStubs" "4.0.2"
+github "antitypical/Result" "0.4.3"


### PR DESCRIPTION
Some API returns 204 and it make a parse error.
So avoid call responseBodyParser and passing dummy data to responseFromObject.