### PR TITLE
More adoption of `static` and `final`

### DIFF
--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -125,11 +125,11 @@ public class API {
         }
     }
     
-    public class func cancelRequest<T: Request>(requestType: T.Type, passingTest test: T -> Bool = { r in true }) {
+    public static func cancelRequest<T: Request>(requestType: T.Type, passingTest test: T -> Bool = { r in true }) {
         cancelRequest(requestType, URLSession: defaultURLSession, passingTest: test)
     }
     
-    public class func cancelRequest<T: Request>(requestType: T.Type, URLSession: NSURLSession, passingTest test: T -> Bool = { r in true }) {
+    public static func cancelRequest<T: Request>(requestType: T.Type, URLSession: NSURLSession, passingTest test: T -> Bool = { r in true }) {
         URLSession.getTasksWithCompletionHandler { dataTasks, uploadTasks, downloadTasks in
             let tasks = (dataTasks + uploadTasks + downloadTasks).filter { task in
                 var request: T?

--- a/APIKit/URLEncodedSerialization.swift
+++ b/APIKit/URLEncodedSerialization.swift
@@ -8,8 +8,8 @@ private func unescape(string: String) -> String {
     return CFURLCreateStringByReplacingPercentEscapes(nil, string, nil) as String
 }
 
-public class URLEncodedSerialization {
-    public class func objectFromData(data: NSData, encoding: NSStringEncoding, error: NSErrorPointer) -> AnyObject? {
+public final class URLEncodedSerialization {
+    public static func objectFromData(data: NSData, encoding: NSStringEncoding, error: NSErrorPointer) -> AnyObject? {
         var dictionary: [String: AnyObject]?
         
         if let string = NSString(data: data, encoding: encoding) as? String {
@@ -32,7 +32,7 @@ public class URLEncodedSerialization {
         return dictionary
     }
     
-    public class func dataFromObject(object: AnyObject, encoding: NSStringEncoding, error: NSErrorPointer) -> NSData? {
+    public static func dataFromObject(object: AnyObject, encoding: NSStringEncoding, error: NSErrorPointer) -> NSData? {
         let string = stringFromObject(object, encoding: encoding)
         let data = string.dataUsingEncoding(encoding, allowLossyConversion: false)
         
@@ -44,7 +44,7 @@ public class URLEncodedSerialization {
         return data
     }
     
-    public class func stringFromObject(object: AnyObject, encoding: NSStringEncoding) -> String {
+    public static func stringFromObject(object: AnyObject, encoding: NSStringEncoding) -> String {
         var pairs = [String]()
         
         if let dictionary = object as? [String: AnyObject] {


### PR DESCRIPTION
:warning:  __This is a breaking change.__ :warning: 

It seems to me that those changed are not meant to be extended or overridden.

But I'm concerned about `API.sendRequest()` method, overriding that might be useful if someone want to modify the returned data task (e.g. set `taskDescription` or `taskIdentifier`).