### PR TITLE
Updates for Xcode 7 beta 3

### DIFF
--- a/APIKit/HTTPMethod.swift
+++ b/APIKit/HTTPMethod.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 public enum HTTPMethod: String {
-    case GET = "GET"
-    case POST = "POST"
-    case PUT = "PUT"
-    case HEAD = "HEAD"
-    case DELETE = "DELETE"
-    case PATCH = "PATCH"
-    case TRACE = "TRACE"
-    case OPTIONS = "OPTIONS"
-    case CONNECT = "CONNECT"
+    case GET
+    case POST
+    case PUT
+    case HEAD
+    case DELETE
+    case PATCH
+    case TRACE
+    case OPTIONS
+    case CONNECT
 }


### PR DESCRIPTION
> If an element of an enum with string raw type does not have an explicit raw value, it will default to the text of the enum’s name.

from [Release Notes](https://developer.apple.com/services-account/download?path=/Developer_Tools/Xcode_7_beta_3/Xcode_7_beta_3_Release_Notes.pdf).