### PR TITLE
More adoption of `static` and `final`

### DIFF
--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -46,11 +46,11 @@ public class API {
         return dataTask
     }
 
-    public class func cancelRequest<T: Request>(requestType: T.Type, passingTest test: T -> Bool = { r in true }) {
+    public static func cancelRequest<T: Request>(requestType: T.Type, passingTest test: T -> Bool = { r in true }) {
         cancelRequest(requestType, URLSession: defaultURLSession, passingTest: test)
     }
 
-    public class func cancelRequest<T: Request>(requestType: T.Type, URLSession: NSURLSession, passingTest test: T -> Bool = { r in true }) {
+    public static func cancelRequest<T: Request>(requestType: T.Type, URLSession: NSURLSession, passingTest test: T -> Bool = { r in true }) {
         URLSession.getTasksWithCompletionHandler { dataTasks, uploadTasks, downloadTasks in
             let allTasks = dataTasks as [NSURLSessionTask]
                 + uploadTasks as [NSURLSessionTask]

--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -13,7 +13,7 @@ public class API {
     )
 
     // send request and build response object
-    public class func sendRequest<T: Request>(request: T, URLSession: NSURLSession = defaultURLSession, handler: (Result<T.Response, APIError>) -> Void = {r in}) -> NSURLSessionDataTask? {
+    public static func sendRequest<T: Request>(request: T, URLSession: NSURLSession = defaultURLSession, handler: (Result<T.Response, APIError>) -> Void = {r in}) -> NSURLSessionDataTask? {
         var dataTask: NSURLSessionDataTask?
 
         switch request.createTaskInURLSession(URLSession) {

--- a/APIKit/URLEncodedSerialization.swift
+++ b/APIKit/URLEncodedSerialization.swift
@@ -8,7 +8,7 @@ private func unescape(string: String) -> String {
     return CFURLCreateStringByReplacingPercentEscapes(nil, string, nil) as String
 }
 
-public class URLEncodedSerialization {
+public final class URLEncodedSerialization {
     public enum Error: ErrorType {
         case CannotGetStringFromData(NSData, NSStringEncoding)
         case CannotGetDataFromString(String, NSStringEncoding)
@@ -17,7 +17,7 @@ public class URLEncodedSerialization {
     }
 
     /// - Throws: URLEncodedSerialization.Error
-    public class func objectFromData(data: NSData, encoding: NSStringEncoding) throws -> [String: String] {
+    public static func objectFromData(data: NSData, encoding: NSStringEncoding) throws -> [String: String] {
         guard let string = NSString(data: data, encoding: encoding) as? String else {
             throw Error.CannotGetStringFromData(data, encoding)
         }
@@ -37,7 +37,7 @@ public class URLEncodedSerialization {
     }
 
     /// - Throws: URLEncodedSerialization.Error
-    public class func dataFromObject(object: AnyObject, encoding: NSStringEncoding) throws -> NSData {
+    public static func dataFromObject(object: AnyObject, encoding: NSStringEncoding) throws -> NSData {
         guard let dictionary = object as? [String: AnyObject] else {
             throw Error.CannotCastObjectToDictionary(object)
         }
@@ -50,7 +50,7 @@ public class URLEncodedSerialization {
         return data
     }
     
-    public class func stringFromDictionary(dictionary: [String: AnyObject]) -> String {
+    public static func stringFromDictionary(dictionary: [String: AnyObject]) -> String {
         let pairs = dictionary.map { key, value -> String in
             let valueAsString = (value as? String) ?? "\(value)"
             return "\(key)=\(escape(valueAsString))"


### PR DESCRIPTION
This is a rebased version of #43.

:warning:  __This is a breaking change.__ :warning: 

It seems to me that those changed are not meant to be extended or overridden.

But I'm concerned about `API.sendRequest()` method, overriding that might be useful if someone want to modify the returned data task (e.g. set `taskDescription` or `taskIdentifier`).