### PR TITLE
Escape via stringByAddingPercentEncodingWithAllowedCharacters

### DIFF
--- a/APIKit/URLEncodedSerialization.swift
+++ b/APIKit/URLEncodedSerialization.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 private func escape(string: String) -> String {
-    return CFURLCreateStringByAddingPercentEscapes(nil, string, nil, "!*'();:@&=+$,/?%#[]", CFStringBuiltInEncodings.UTF8.rawValue) as String
+    //Reserved characters defined by RFC 3986
+    let genDelims = ":/?#[]@"
+    let subDelims = "!$&'()*+,;="
+    let reservedCharacters = genDelims + subDelims
+    let allowedCharacterSet = NSCharacterSet.URLQueryAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
+    allowedCharacterSet.removeCharactersInString(reservedCharacters)
+    return string.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet) ?? string
 }
 
 private func unescape(string: String) -> String {


### PR DESCRIPTION
Thanks for the marvelous library.

`CFURLCreateStringByAddingPercentEscapes` is deprecated since iOS9 SDK.
https://developer.apple.com/library/prerelease/ios/releasenotes/General/iOS90APIDiffs/Objective-C/CoreFoundation.html

APIKit uses this API at https://github.com/ishkawa/APIKit/blob/master/APIKit/URLEncodedSerialization.swift#L4

Therefore, I replaced this deprecated API with `stringByAddingPercentEncodingWithAllowedCharacters` method based on [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt).

I'd appreciated it if you would review this PR when you have enough time.