### PR TITLE
Replace createTaskInURLSession() with buildURLRequest()

### DIFF
--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -19,8 +19,8 @@ public class API {
             handler(.Failure(error))
             return nil
 
-        case .Success(let URLReqeust):
-            let dataTask = URLSession.dataTaskWithRequest(URLReqeust)
+        case .Success(let URLRequest):
+            let dataTask = URLSession.dataTaskWithRequest(URLRequest)
             dataTask.request = Box(request)
             dataTask.completionHandler = { data, URLResponse, connectionError in
                 let sessionResult: Result<(NSData, NSURLResponse?), APIError>

--- a/APIKit/API.swift
+++ b/APIKit/API.swift
@@ -14,16 +14,15 @@ public class API {
 
     // send request and build response object
     public static func sendRequest<T: Request>(request: T, URLSession: NSURLSession = defaultURLSession, handler: (Result<T.Response, APIError>) -> Void = {r in}) -> NSURLSessionDataTask? {
-        var dataTask: NSURLSessionDataTask?
-
-        switch request.createTaskInURLSession(URLSession) {
+        switch request.buildURLRequest() {
         case .Failure(let error):
             handler(.Failure(error))
+            return nil
 
-        case .Success(let task):
-            dataTask = task
-            task.request = Box(request)
-            task.completionHandler = { data, URLResponse, connectionError in
+        case .Success(let URLReqeust):
+            let dataTask = URLSession.dataTaskWithRequest(URLReqeust)
+            dataTask.request = Box(request)
+            dataTask.completionHandler = { data, URLResponse, connectionError in
                 let sessionResult: Result<(NSData, NSURLResponse?), APIError>
                 if let error = connectionError {
                     sessionResult = .Failure(.ConnectionError(error))
@@ -40,10 +39,10 @@ public class API {
                 }
             }
             
-            task.resume()
+            dataTask.resume()
+            
+            return dataTask
         }
-
-        return dataTask
     }
 
     public static func cancelRequest<T: Request>(requestType: T.Type, passingTest test: T -> Bool = { r in true }) {

--- a/APIKit/Request.swift
+++ b/APIKit/Request.swift
@@ -68,9 +68,10 @@ public extension Request {
     public func errorFromObject(object: AnyObject, URLResponse: NSHTTPURLResponse) -> ErrorType? {
         return NSError(domain: "APIKitErrorDomain", code: 0, userInfo: ["object":object, "URLResponse": URLResponse])
     }
-
-    // Use Result here because `throws` loses type info of an error (in Swift 2 beta 2)
-    internal func createTaskInURLSession(URLSession: NSURLSession) -> Result<NSURLSessionDataTask, APIError> {
+    
+    // Use Result here because `throws` loses type info of an error.
+    // This method is not overridable. If you need to add customization, override configureURLRequest.
+    public func buildURLRequest() -> Result<NSURLRequest, APIError> {
         let URL = path.isEmpty ? baseURL : baseURL.URLByAppendingPathComponent(path)
         guard let components = NSURLComponents(URL: URL, resolvingAgainstBaseURL: true) else {
             return .Failure(.InvalidBaseURL(baseURL))
@@ -101,10 +102,8 @@ public extension Request {
         } catch {
             return .Failure(.ConfigurationError(error))
         }
-
-        let task = URLSession.dataTaskWithRequest(URLRequest)
-
-        return .Success(task)
+        
+        return .Success(URLRequest)
     }
 
     // Use Result here because `throws` loses type info of an error (in Swift 2 beta 2)

--- a/APIKitTests/RequestCreateTaskInURLSessionTests.swift
+++ b/APIKitTests/RequestCreateTaskInURLSessionTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import OHHTTPStubs
-@testable import APIKit
+import APIKit
 
 class RequestCreateTaskInURLSessionTest: XCTestCase {
     
@@ -37,14 +37,10 @@ class RequestCreateTaskInURLSessionTest: XCTestCase {
         
         func assertRequest(sampleRequest: SampleRequest, pattern: String) {
             
-            switch sampleRequest.createTaskInURLSession(session) {
-            case let .Success(task):
-                guard let urlRequest = task.originalRequest else {
-                    XCTFail("The created task doesn't have a valid NSURLRequest: \(task)")
-                    return
-                }
-                guard let url = urlRequest.URL else {
-                    XCTFail("The created task doesn't have a valid URL: \(urlRequest)")
+            switch sampleRequest.buildURLRequest() {
+            case let .Success(URLRequest):
+                guard let url = URLRequest.URL else {
+                    XCTFail("The created task doesn't have a valid URL: \(URLRequest)")
                     return
                 }
                 XCTAssertEqual(url.absoluteString, pattern)


### PR DESCRIPTION
Exposing final NSURLRequest makes debugging easy.

In early beta, NSURLSession.sendRequest() returned NSURLSessionDataTask?, so we had to handle errors of this method. The purpose of createTaskInURLSession() was putting error handling into 1 place, but now it is not necessary.