### PR TITLE
Fix parameter type from [String:AnyObject] to [String:AnyObject?] for nullable value.

### DIFF
--- a/APIKit/URLEncodedSerialization.swift
+++ b/APIKit/URLEncodedSerialization.swift
@@ -62,6 +62,10 @@ public final class URLEncodedSerialization {
     
     public static func stringFromDictionary(dictionary: [String: AnyObject]) -> String {
         let pairs = dictionary.map { key, value -> String in
+            guard (value is NSNull) == false else {
+                return "\(escape(key))"
+            }
+            
             let valueAsString = (value as? String) ?? "\(value)"
             return "\(escape(key))=\(escape(valueAsString))"
         }

--- a/APIKitTests/RequestCreateTaskInURLSessionTests.swift
+++ b/APIKitTests/RequestCreateTaskInURLSessionTests.swift
@@ -18,7 +18,7 @@ class RequestCreateTaskInURLSessionTest: XCTestCase {
         var baseURL: NSURL { return NSURL(string: b)! }
         var method: HTTPMethod { return m }
         var path: String { return p  }
-        var parameters: [String: AnyObject] { return params }
+        var parameters: [String: AnyObject?] { return params }
         func responseFromObject(object: AnyObject, URLResponse: NSHTTPURLResponse) -> Response? { return nil }
     }
     

--- a/APIKitTests/RequestTests.swift
+++ b/APIKitTests/RequestTests.swift
@@ -17,9 +17,10 @@ class RequestTests: XCTestCase {
             return "/"
         }
         
-        var parameters: [String: AnyObject] {
+        var parameters: [String: AnyObject?] {
             return [
                 "q": query,
+                "dummy": nil
             ]
         }
         
@@ -35,7 +36,7 @@ class RequestTests: XCTestCase {
 
     func testJapanesesURLQueryParameterEncoding() {
         OHHTTPStubs.stubRequestsPassingTest({ request in
-            XCTAssert(request.URL?.query == "q=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF")
+            XCTAssert(request.URL?.query == "q=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF&dummy")
             return true
         }, withStubResponse: { request in
             return OHHTTPStubsResponse(data: NSData(), statusCode: 200, headers: nil)
@@ -53,7 +54,7 @@ class RequestTests: XCTestCase {
     
     func testSymbolURLQueryParameterEncoding() {
         OHHTTPStubs.stubRequestsPassingTest({ request in
-            XCTAssert(request.URL?.query == "q=%21%22%23%24%25%26%27%28%290%3D~%7C%60%7B%7D%2A%2B%3C%3E%3F_")
+            XCTAssert(request.URL?.query == "q=%21%22%23%24%25%26%27%28%290%3D~%7C%60%7B%7D%2A%2B%3C%3E%3F_&dummy")
             return true
         }, withStubResponse: { request in
             return OHHTTPStubsResponse(data: NSData(), statusCode: 200, headers: nil)


### PR DESCRIPTION
Fixed parameter handling when its value is null.

For example, there are some scenarios when `some_api?query=&page=1` should be replaced as `some_api?query&page=1` (no `query=`).