### PR TITLE
Change access level of RequestType.parseData() to public.

### DIFF
--- a/APIKit/RequestType.swift
+++ b/APIKit/RequestType.swift
@@ -111,7 +111,7 @@ public extension RequestType {
     }
 
     // Use Result here because `throws` loses type info of an error (in Swift 2 beta 2)
-    internal func parseData(data: NSData, URLResponse: NSURLResponse?) -> Result<Self.Response, APIError> {
+    public func parseData(data: NSData, URLResponse: NSURLResponse?) -> Result<Self.Response, APIError> {
         guard let HTTPURLResponse = URLResponse as? NSHTTPURLResponse else {
             return .Failure(.NotHTTPURLResponse(URLResponse))
         }


### PR DESCRIPTION
This fix will be helpful if one wants to use `RequestType` without pre-installed `Session` class.
In my case, there is already a custom session client class (which doesn't use NSURLSession).