### PR TITLE
stop calling parameters variable twice

### DIFF
--- a/APIKit/RequestType.swift
+++ b/APIKit/RequestType.swift
@@ -82,6 +82,7 @@ public extension RequestType {
         }
 
         let URLRequest = NSMutableURLRequest()
+        let parameters = self.parameters
 
         switch method {
         case .GET, .HEAD, .DELETE:


### PR DESCRIPTION
Because `parameters` computed property in RequestType protocol is called twice in it's `buildURLRequest` method, I bind it to local variable once.

---

`RequestType` プロトコルの `parameters` プロパティが重複して呼ばれるので、一度ローカル変数にセットするようにしてみました。