### PR TITLE
Replace the deprecated function `XCPExecutionShouldContinueIndefinitely()`

### DIFF
--- a/Demo.playground/Contents.swift
+++ b/Demo.playground/Contents.swift
@@ -2,7 +2,7 @@ import XCPlayground
 import UIKit
 import APIKit
 
-XCPSetExecutionShouldContinueIndefinitely()
+XCPlaygroundPage.currentPage.needsIndefiniteExecution = true
 
 //: Step 1: Define request protocol
 protocol GitHubRequestType: RequestType {


### PR DESCRIPTION
This function has been deprecated in favor of `XCPlaygroundPage.needsIndefiniteExecution`.