### PR TITLE
Remove "brew install carthage"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
 
 before_install:
   - brew update 
-  - brew install carthage
 
 install:
   - carthage bootstrap --use-submodules --no-build


### PR DESCRIPTION
It is already installed and will cause Travis build to fail.
If you want to use the latest version of `carthage`, here is the only
way (works but dirty) that I know:

    brew uninstall carthage && brew install carthage