### PR TITLE
multipart/form-data support

### DIFF
--- a/APIKit.xcodeproj/project.pbxproj
+++ b/APIKit.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		141F12321C1C9AC70026D415 /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD51152D1B1FFCC700514240 /* OHHTTPStubs.framework */; };
 		141F12361C1C9AC70026D415 /* Result.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = CD5115241B1FFBA900514240 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		141F12371C1C9AC70026D415 /* OHHTTPStubs.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = CD51152D1B1FFCC700514240 /* OHHTTPStubs.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		269549D91C66146A00448370 /* MultipartFormDataSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269549D81C66146A00448370 /* MultipartFormDataSerialization.swift */; };
+		269549DA1C66146A00448370 /* MultipartFormDataSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269549D81C66146A00448370 /* MultipartFormDataSerialization.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -49,6 +51,7 @@
 		141F123F1C1C9EA30026D415 /* APIKit.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = APIKit.xcconfig; path = Configurations/APIKit.xcconfig; sourceTree = "<group>"; };
 		141F12401C1C9EA30026D415 /* Tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Tests.xcconfig; path = Configurations/Tests.xcconfig; sourceTree = "<group>"; };
 		19C16B531B83327A001D77CC /* RequestTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTypeTests.swift; sourceTree = "<group>"; };
+		269549D81C66146A00448370 /* MultipartFormDataSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormDataSerialization.swift; sourceTree = "<group>"; };
 		7F0869A51A978BCA001AD3E1 /* URLEncodedSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLEncodedSerialization.swift; sourceTree = "<group>"; };
 		7F1B190A1AA2CA1300C7AFCF /* APITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APITests.swift; sourceTree = "<group>"; };
 		7F30A8551A975BD600A8C136 /* RequestBodyBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestBodyBuilderTests.swift; sourceTree = "<group>"; };
@@ -131,6 +134,7 @@
 				7F0869A51A978BCA001AD3E1 /* URLEncodedSerialization.swift */,
 				7FCBE9DC1A9734880075AFD9 /* RequestBodyBuilder.swift */,
 				7FCBE9DF1A9734950075AFD9 /* ResponseBodyParser.swift */,
+				269549D81C66146A00448370 /* MultipartFormDataSerialization.swift */,
 				7F45FCE01A94D02C006863BB /* Supporting Files */,
 			);
 			path = APIKit;
@@ -271,6 +275,7 @@
 				141F121A1C1C9ABE0026D415 /* HTTPMethod.swift in Sources */,
 				141F121B1C1C9ABE0026D415 /* RequestType.swift in Sources */,
 				141F121C1C1C9ABE0026D415 /* ResponseBodyParser.swift in Sources */,
+				269549D91C66146A00448370 /* MultipartFormDataSerialization.swift in Sources */,
 				141F121D1C1C9ABE0026D415 /* APIError.swift in Sources */,
 				141F121E1C1C9ABE0026D415 /* URLEncodedSerialization.swift in Sources */,
 			);
@@ -282,6 +287,7 @@
 			files = (
 				141F122C1C1C9AC70026D415 /* APITests.swift in Sources */,
 				141F122D1C1C9AC70026D415 /* RequestTypeTests.swift in Sources */,
+				269549DA1C66146A00448370 /* MultipartFormDataSerialization.swift in Sources */,
 				141F122E1C1C9AC70026D415 /* ResponseBodyParserTests.swift in Sources */,
 				141F122F1C1C9AC70026D415 /* RequestBodyBuilderTests.swift in Sources */,
 			);

--- a/APIKit/MultipartFormDataSerialization.swift
+++ b/APIKit/MultipartFormDataSerialization.swift
@@ -1,0 +1,718 @@
+import Foundation
+
+#if os(iOS) || os(watchOS) || os(tvOS)
+    import MobileCoreServices
+#elseif os(OSX)
+    import CoreServices
+#endif
+
+public final class MultipartFormDataSerialization {
+    public enum Error: ErrorType {
+        case CannotCastObjectToSupportedType(AnyObject)
+        case UnsupportedType(String, AnyObject)
+
+        case NSURLErrorBadURL(String)
+        case NSURLErrorCannotOpenFile(String)
+        case InputStreamReadFailed(String)
+        case OutputStreamWriteFailed(String)
+    }
+
+    public final class Parameter {
+        private enum Type {
+            case DataWithMimeType(data: NSData, mimeType: String)
+            case DataWithFileNameMimeType(data: NSData, fileName: String, mimeType: String)
+            case FileURLWithFileNameMimeType(fileURL: NSURL, fileName: String, mimeType: String)
+        }
+
+        private let type: Type
+
+        public init(data: NSData, mimeType: String) {
+            type = .DataWithMimeType(data: data, mimeType: mimeType)
+        }
+
+        public init(data: NSData, fileName: String, mimeType: String) {
+            type = .DataWithFileNameMimeType(data: data, fileName: fileName, mimeType: mimeType)
+        }
+
+        public init(fileURL: NSURL, fileName: String, mimeType: String) {
+            type = .FileURLWithFileNameMimeType(fileURL: fileURL, fileName: fileName, mimeType: mimeType)
+        }
+    }
+
+    public static func dataFromObject(object: AnyObject) throws -> (boundary: String, body: NSData) {
+        switch object {
+        case let array as [(String, AnyObject)]:
+            return try dataFromArray(array)
+
+        case let dictionary as [String : AnyObject] :
+            let array = dictionary.map { key, val in (key, val) }
+            return try dataFromArray(array)
+
+        default:
+            throw Error.CannotCastObjectToSupportedType(object)
+        }
+    }
+
+    private static func dataFromArray(array: [(String, AnyObject)]) throws -> (boundary: String, body: NSData) {
+        let encoder = MultipartFormData()
+
+        for (key, val) in array {
+            switch val {
+            case let parameter as Parameter:
+                switch parameter.type {
+                case .DataWithMimeType(let data, let mimeType):
+                    encoder.appendBodyPart(data: data, name: key, mimeType: mimeType)
+
+                case .DataWithFileNameMimeType(let data, let fileName, let mimeType):
+                    encoder.appendBodyPart(data: data, name: key, fileName: fileName, mimeType: mimeType)
+
+                case .FileURLWithFileNameMimeType(let fileURL, let fileName, let mimeType):
+                    encoder.appendBodyPart(fileURL: fileURL, name: key, fileName: fileName, mimeType: mimeType)
+                }
+
+            case let data as NSData:
+                encoder.appendBodyPart(data: data, name: key)
+
+            case let fileURL as NSURL where fileURL.fileURL:
+                encoder.appendBodyPart(fileURL: fileURL, name: key)
+
+            // avoid cast problem e.g. "Bool -> AnyObject -> Int"
+            case let bool as NSNumber where bool.isKindOfClass(objc_getClass("__NSCFBoolean") as! AnyClass):
+                guard let data = "\(bool.boolValue)".dataUsingEncoding(NSUTF8StringEncoding) else {
+                    throw Error.UnsupportedType(key, val)
+                }
+                encoder.appendBodyPart(data: data, name: key)
+
+            case let number as NSNumber:
+                guard let data = "\(number)".dataUsingEncoding(NSUTF8StringEncoding) else {
+                    throw Error.UnsupportedType(key, val)
+                }
+                encoder.appendBodyPart(data: data, name: key)
+
+            case let string as String:
+                guard let data = string.dataUsingEncoding(NSUTF8StringEncoding) else {
+                    throw Error.UnsupportedType(key, val)
+                }
+                encoder.appendBodyPart(data: data, name: key)
+
+            default:
+                throw Error.UnsupportedType(key, val)
+            }
+        }
+
+        return (encoder.boundary, try encoder.encode())
+    }
+}
+
+
+/**
+  Copied from [Alamofire](https://github.com/Alamofire/Alamofire).
+**/
+
+/**
+ Constructs `multipart/form-data` for uploads within an HTTP or HTTPS body. There are currently two ways to encode
+ multipart form data. The first way is to encode the data directly in memory. This is very efficient, but can lead
+ to memory issues if the dataset is too large. The second way is designed for larger datasets and will write all the
+ data to a single file on disk with all the proper boundary segmentation. The second approach MUST be used for
+ larger datasets such as video content, otherwise your app may run out of memory when trying to encode the dataset.
+ For more information on `multipart/form-data` in general, please refer to the RFC-2388 and RFC-2045 specs as well
+ and the w3 form documentation.
+ - https://www.ietf.org/rfc/rfc2388.txt
+ - https://www.ietf.org/rfc/rfc2045.txt
+ - https://www.w3.org/TR/html401/interact/forms.html#h-17.13
+ */
+private final class MultipartFormData {
+    // MARK: - Helper Types
+
+    struct EncodingCharacters {
+        static let CRLF = "\r\n"
+    }
+
+    struct BoundaryGenerator {
+        enum BoundaryType {
+            case Initial, Encapsulated, Final
+        }
+
+        static func randomBoundary() -> String {
+            return String(format: "alamofire.boundary.%08x%08x", arc4random(), arc4random())
+        }
+
+        static func boundaryData(boundaryType boundaryType: BoundaryType, boundary: String) -> NSData {
+            let boundaryText: String
+
+            switch boundaryType {
+            case .Initial:
+                boundaryText = "--\(boundary)\(EncodingCharacters.CRLF)"
+            case .Encapsulated:
+                boundaryText = "\(EncodingCharacters.CRLF)--\(boundary)\(EncodingCharacters.CRLF)"
+            case .Final:
+                boundaryText = "\(EncodingCharacters.CRLF)--\(boundary)--\(EncodingCharacters.CRLF)"
+            }
+
+            return boundaryText.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!
+        }
+    }
+
+    class BodyPart {
+        let headers: [String: String]
+        let bodyStream: NSInputStream
+        let bodyContentLength: UInt64
+        var hasInitialBoundary = false
+        var hasFinalBoundary = false
+
+        init(headers: [String: String], bodyStream: NSInputStream, bodyContentLength: UInt64) {
+            self.headers = headers
+            self.bodyStream = bodyStream
+            self.bodyContentLength = bodyContentLength
+        }
+    }
+
+    // MARK: - Properties
+
+    /// The `Content-Type` header value containing the boundary used to generate the `multipart/form-data`.
+    var contentType: String { return "multipart/form-data; boundary=\(boundary)" }
+
+    /// The content length of all body parts used to generate the `multipart/form-data` not including the boundaries.
+    var contentLength: UInt64 { return bodyParts.reduce(0) { $0 + $1.bodyContentLength } }
+
+    /// The boundary used to separate the body parts in the encoded form data.
+    let boundary: String
+
+    private var bodyParts: [BodyPart]
+    private var bodyPartError: ErrorType?
+    private let streamBufferSize: Int
+
+    // MARK: - Lifecycle
+
+    /**
+    Creates a multipart form data object.
+    - returns: The multipart form data object.
+    */
+    init() {
+        self.boundary = BoundaryGenerator.randomBoundary()
+        self.bodyParts = []
+
+        /**
+        *  The optimal read/write buffer size in bytes for input and output streams is 1024 (1KB). For more
+        *  information, please refer to the following article:
+        *    - https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Streams/Articles/ReadingInputStreams.html
+        */
+
+        self.streamBufferSize = 1024
+    }
+
+    // MARK: - Body Parts
+
+    /**
+    Creates a body part from the data and appends it to the multipart form data object.
+    The body part data will be encoded using the following format:
+    - `Content-Disposition: form-data; name=#{name}` (HTTP Header)
+    - Encoded data
+    - Multipart form boundary
+    - parameter data: The data to encode into the multipart form data.
+    - parameter name: The name to associate with the data in the `Content-Disposition` HTTP header.
+    */
+    private func appendBodyPart(data data: NSData, name: String) {
+        let headers = contentHeaders(name: name)
+        let stream = NSInputStream(data: data)
+        let length = UInt64(data.length)
+
+        appendBodyPart(stream: stream, length: length, headers: headers)
+    }
+
+    /**
+     Creates a body part from the data and appends it to the multipart form data object.
+     The body part data will be encoded using the following format:
+     - `Content-Disposition: form-data; name=#{name}` (HTTP Header)
+     - `Content-Type: #{generated mimeType}` (HTTP Header)
+     - Encoded data
+     - Multipart form boundary
+     - parameter data:     The data to encode into the multipart form data.
+     - parameter name:     The name to associate with the data in the `Content-Disposition` HTTP header.
+     - parameter mimeType: The MIME type to associate with the data content type in the `Content-Type` HTTP header.
+     */
+    func appendBodyPart(data data: NSData, name: String, mimeType: String) {
+        let headers = contentHeaders(name: name, mimeType: mimeType)
+        let stream = NSInputStream(data: data)
+        let length = UInt64(data.length)
+
+        appendBodyPart(stream: stream, length: length, headers: headers)
+    }
+
+    /**
+     Creates a body part from the data and appends it to the multipart form data object.
+     The body part data will be encoded using the following format:
+     - `Content-Disposition: form-data; name=#{name}; filename=#{filename}` (HTTP Header)
+     - `Content-Type: #{mimeType}` (HTTP Header)
+     - Encoded file data
+     - Multipart form boundary
+     - parameter data:     The data to encode into the multipart form data.
+     - parameter name:     The name to associate with the data in the `Content-Disposition` HTTP header.
+     - parameter fileName: The filename to associate with the data in the `Content-Disposition` HTTP header.
+     - parameter mimeType: The MIME type to associate with the data in the `Content-Type` HTTP header.
+     */
+    func appendBodyPart(data data: NSData, name: String, fileName: String, mimeType: String) {
+        let headers = contentHeaders(name: name, fileName: fileName, mimeType: mimeType)
+        let stream = NSInputStream(data: data)
+        let length = UInt64(data.length)
+
+        appendBodyPart(stream: stream, length: length, headers: headers)
+    }
+
+    /**
+     Creates a body part from the file and appends it to the multipart form data object.
+     The body part data will be encoded using the following format:
+     - `Content-Disposition: form-data; name=#{name}; filename=#{generated filename}` (HTTP Header)
+     - `Content-Type: #{generated mimeType}` (HTTP Header)
+     - Encoded file data
+     - Multipart form boundary
+     The filename in the `Content-Disposition` HTTP header is generated from the last path component of the
+     `fileURL`. The `Content-Type` HTTP header MIME type is generated by mapping the `fileURL` extension to the
+     system associated MIME type.
+     - parameter fileURL: The URL of the file whose content will be encoded into the multipart form data.
+     - parameter name:    The name to associate with the file content in the `Content-Disposition` HTTP header.
+     */
+    func appendBodyPart(fileURL fileURL: NSURL, name: String) {
+        if let
+            fileName = fileURL.lastPathComponent,
+            pathExtension = fileURL.pathExtension
+        {
+            let mimeType = mimeTypeForPathExtension(pathExtension)
+            appendBodyPart(fileURL: fileURL, name: name, fileName: fileName, mimeType: mimeType)
+        } else {
+            let failureReason = "Failed to extract the fileName of the provided URL: \(fileURL)"
+            setBodyPartError(MultipartFormDataSerialization.Error.NSURLErrorBadURL(failureReason))
+        }
+    }
+
+    /**
+     Creates a body part from the file and appends it to the multipart form data object.
+     The body part data will be encoded using the following format:
+     - Content-Disposition: form-data; name=#{name}; filename=#{filename} (HTTP Header)
+     - Content-Type: #{mimeType} (HTTP Header)
+     - Encoded file data
+     - Multipart form boundary
+     - parameter fileURL:  The URL of the file whose content will be encoded into the multipart form data.
+     - parameter name:     The name to associate with the file content in the `Content-Disposition` HTTP header.
+     - parameter fileName: The filename to associate with the file content in the `Content-Disposition` HTTP header.
+     - parameter mimeType: The MIME type to associate with the file content in the `Content-Type` HTTP header.
+     */
+    func appendBodyPart(fileURL fileURL: NSURL, name: String, fileName: String, mimeType: String) {
+        let headers = contentHeaders(name: name, fileName: fileName, mimeType: mimeType)
+
+        //============================================================
+        //                 Check 1 - is file URL?
+        //============================================================
+
+        guard fileURL.fileURL else {
+            let failureReason = "The file URL does not point to a file URL: \(fileURL)"
+            let error = MultipartFormDataSerialization.Error.NSURLErrorBadURL(failureReason)
+            setBodyPartError(error)
+            return
+        }
+
+        //============================================================
+        //              Check 2 - is file URL reachable?
+        //============================================================
+
+        var isReachable = true
+
+        if #available(OSX 10.10, *) {
+            isReachable = fileURL.checkPromisedItemIsReachableAndReturnError(nil)
+        }
+
+        guard isReachable else {
+            let error = MultipartFormDataSerialization.Error.NSURLErrorBadURL("The file URL is not reachable: \(fileURL)")
+            setBodyPartError(error)
+            return
+        }
+
+        //============================================================
+        //            Check 3 - is file URL a directory?
+        //============================================================
+
+        var isDirectory: ObjCBool = false
+
+        guard let
+            path = fileURL.path
+            where NSFileManager.defaultManager().fileExistsAtPath(path, isDirectory: &isDirectory) && !isDirectory else
+        {
+            let failureReason = "The file URL is a directory, not a file: \(fileURL)"
+            let error = MultipartFormDataSerialization.Error.NSURLErrorBadURL(failureReason)
+            setBodyPartError(error)
+            return
+        }
+
+        //============================================================
+        //          Check 4 - can the file size be extracted?
+        //============================================================
+
+        var bodyContentLength: UInt64?
+
+        do {
+            if let
+                path = fileURL.path,
+                fileSize = try NSFileManager.defaultManager().attributesOfItemAtPath(path)[NSFileSize] as? NSNumber
+            {
+                bodyContentLength = fileSize.unsignedLongLongValue
+            }
+        } catch {
+            // No-op
+        }
+
+        guard let length = bodyContentLength else {
+            let failureReason = "Could not fetch attributes from the file URL: \(fileURL)"
+            let error = MultipartFormDataSerialization.Error.NSURLErrorBadURL(failureReason)
+            setBodyPartError(error)
+            return
+        }
+
+        //============================================================
+        //       Check 5 - can a stream be created from file URL?
+        //============================================================
+
+        guard let stream = NSInputStream(URL: fileURL) else {
+            let failureReason = "Failed to create an input stream from the file URL: \(fileURL)"
+            let error = MultipartFormDataSerialization.Error.NSURLErrorCannotOpenFile(failureReason)
+            setBodyPartError(error)
+            return
+        }
+
+        appendBodyPart(stream: stream, length: length, headers: headers)
+    }
+
+    /**
+     Creates a body part from the stream and appends it to the multipart form data object.
+     The body part data will be encoded using the following format:
+     - `Content-Disposition: form-data; name=#{name}; filename=#{filename}` (HTTP Header)
+     - `Content-Type: #{mimeType}` (HTTP Header)
+     - Encoded stream data
+     - Multipart form boundary
+     - parameter stream:   The input stream to encode in the multipart form data.
+     - parameter length:   The content length of the stream.
+     - parameter name:     The name to associate with the stream content in the `Content-Disposition` HTTP header.
+     - parameter fileName: The filename to associate with the stream content in the `Content-Disposition` HTTP header.
+     - parameter mimeType: The MIME type to associate with the stream content in the `Content-Type` HTTP header.
+     */
+    func appendBodyPart(
+        stream stream: NSInputStream,
+        length: UInt64,
+        name: String,
+        fileName: String,
+        mimeType: String)
+    {
+        let headers = contentHeaders(name: name, fileName: fileName, mimeType: mimeType)
+        appendBodyPart(stream: stream, length: length, headers: headers)
+    }
+
+    /**
+     Creates a body part with the headers, stream and length and appends it to the multipart form data object.
+     The body part data will be encoded using the following format:
+     - HTTP headers
+     - Encoded stream data
+     - Multipart form boundary
+     - parameter stream:  The input stream to encode in the multipart form data.
+     - parameter length:  The content length of the stream.
+     - parameter headers: The HTTP headers for the body part.
+     */
+    func appendBodyPart(stream stream: NSInputStream, length: UInt64, headers: [String: String]) {
+        let bodyPart = BodyPart(headers: headers, bodyStream: stream, bodyContentLength: length)
+        bodyParts.append(bodyPart)
+    }
+
+    // MARK: - Data Encoding
+
+    /**
+    Encodes all the appended body parts into a single `NSData` object.
+    It is important to note that this method will load all the appended body parts into memory all at the same
+    time. This method should only be used when the encoded data will have a small memory footprint. For large data
+    cases, please use the `writeEncodedDataToDisk(fileURL:completionHandler:)` method.
+    - throws: An `NSError` if encoding encounters an error.
+    - returns: The encoded `NSData` if encoding is successful.
+    */
+    func encode() throws -> NSData {
+        if let bodyPartError = bodyPartError {
+            throw bodyPartError
+        }
+
+        let encoded = NSMutableData()
+
+        bodyParts.first?.hasInitialBoundary = true
+        bodyParts.last?.hasFinalBoundary = true
+
+        for bodyPart in bodyParts {
+            let encodedData = try encodeBodyPart(bodyPart)
+            encoded.appendData(encodedData)
+        }
+
+        return encoded
+    }
+
+    /**
+     Writes the appended body parts into the given file URL.
+     This process is facilitated by reading and writing with input and output streams, respectively. Thus,
+     this approach is very memory efficient and should be used for large body part data.
+     - parameter fileURL: The file URL to write the multipart form data into.
+     - throws: An `NSError` if encoding encounters an error.
+     */
+    func writeEncodedDataToDisk(fileURL: NSURL) throws {
+        if let bodyPartError = bodyPartError {
+            throw bodyPartError
+        }
+
+        if let path = fileURL.path where NSFileManager.defaultManager().fileExistsAtPath(path) {
+            let failureReason = "A file already exists at the given file URL: \(fileURL)"
+            throw MultipartFormDataSerialization.Error.NSURLErrorBadURL(failureReason)
+        } else if !fileURL.fileURL {
+            let failureReason = "The URL does not point to a valid file: \(fileURL)"
+            throw MultipartFormDataSerialization.Error.NSURLErrorBadURL(failureReason)
+        }
+
+        let outputStream: NSOutputStream
+
+        if let possibleOutputStream = NSOutputStream(URL: fileURL, append: false) {
+            outputStream = possibleOutputStream
+        } else {
+            let failureReason = "Failed to create an output stream with the given URL: \(fileURL)"
+            throw MultipartFormDataSerialization.Error.NSURLErrorCannotOpenFile(failureReason)
+        }
+
+        outputStream.scheduleInRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
+        outputStream.open()
+
+        self.bodyParts.first?.hasInitialBoundary = true
+        self.bodyParts.last?.hasFinalBoundary = true
+
+        for bodyPart in self.bodyParts {
+            try writeBodyPart(bodyPart, toOutputStream: outputStream)
+        }
+
+        outputStream.close()
+        outputStream.removeFromRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
+    }
+
+    // MARK: - Private - Body Part Encoding
+
+    private func encodeBodyPart(bodyPart: BodyPart) throws -> NSData {
+        let encoded = NSMutableData()
+
+        let initialData = bodyPart.hasInitialBoundary ? initialBoundaryData() : encapsulatedBoundaryData()
+        encoded.appendData(initialData)
+
+        let headerData = encodeHeaderDataForBodyPart(bodyPart)
+        encoded.appendData(headerData)
+
+        let bodyStreamData = try encodeBodyStreamDataForBodyPart(bodyPart)
+        encoded.appendData(bodyStreamData)
+
+        if bodyPart.hasFinalBoundary {
+            encoded.appendData(finalBoundaryData())
+        }
+
+        return encoded
+    }
+
+    private func encodeHeaderDataForBodyPart(bodyPart: BodyPart) -> NSData {
+        var headerText = ""
+
+        for (key, value) in bodyPart.headers {
+            headerText += "\(key): \(value)\(EncodingCharacters.CRLF)"
+        }
+        headerText += EncodingCharacters.CRLF
+
+        return headerText.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!
+    }
+
+    private func encodeBodyStreamDataForBodyPart(bodyPart: BodyPart) throws -> NSData {
+        let inputStream = bodyPart.bodyStream
+        inputStream.scheduleInRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
+        inputStream.open()
+
+        var error: ErrorType?
+        let encoded = NSMutableData()
+
+        while inputStream.hasBytesAvailable {
+            var buffer = [UInt8](count: streamBufferSize, repeatedValue: 0)
+            let bytesRead = inputStream.read(&buffer, maxLength: streamBufferSize)
+
+            if inputStream.streamError != nil {
+                error = inputStream.streamError
+                break
+            }
+
+            if bytesRead > 0 {
+                encoded.appendBytes(buffer, length: bytesRead)
+            } else if bytesRead < 0 {
+                let failureReason = "Failed to read from input stream: \(inputStream)"
+                error = MultipartFormDataSerialization.Error.InputStreamReadFailed(failureReason)
+                break
+            } else {
+                break
+            }
+        }
+
+        inputStream.close()
+        inputStream.removeFromRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
+
+        if let error = error {
+            throw error
+        }
+
+        return encoded
+    }
+
+    // MARK: - Private - Writing Body Part to Output Stream
+
+    private func writeBodyPart(bodyPart: BodyPart, toOutputStream outputStream: NSOutputStream) throws {
+        try writeInitialBoundaryDataForBodyPart(bodyPart, toOutputStream: outputStream)
+        try writeHeaderDataForBodyPart(bodyPart, toOutputStream: outputStream)
+        try writeBodyStreamForBodyPart(bodyPart, toOutputStream: outputStream)
+        try writeFinalBoundaryDataForBodyPart(bodyPart, toOutputStream: outputStream)
+    }
+
+    private func writeInitialBoundaryDataForBodyPart(
+        bodyPart: BodyPart,
+        toOutputStream outputStream: NSOutputStream)
+        throws
+    {
+        let initialData = bodyPart.hasInitialBoundary ? initialBoundaryData() : encapsulatedBoundaryData()
+        return try writeData(initialData, toOutputStream: outputStream)
+    }
+
+    private func writeHeaderDataForBodyPart(bodyPart: BodyPart, toOutputStream outputStream: NSOutputStream) throws {
+        let headerData = encodeHeaderDataForBodyPart(bodyPart)
+        return try writeData(headerData, toOutputStream: outputStream)
+    }
+
+    private func writeBodyStreamForBodyPart(bodyPart: BodyPart, toOutputStream outputStream: NSOutputStream) throws {
+        let inputStream = bodyPart.bodyStream
+        inputStream.scheduleInRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
+        inputStream.open()
+
+        while inputStream.hasBytesAvailable {
+            var buffer = [UInt8](count: streamBufferSize, repeatedValue: 0)
+            let bytesRead = inputStream.read(&buffer, maxLength: streamBufferSize)
+
+            if let streamError = inputStream.streamError {
+                throw streamError
+            }
+
+            if bytesRead > 0 {
+                if buffer.count != bytesRead {
+                    buffer = Array(buffer[0..<bytesRead])
+                }
+
+                try writeBuffer(&buffer, toOutputStream: outputStream)
+            } else if bytesRead < 0 {
+                let failureReason = "Failed to read from input stream: \(inputStream)"
+                throw MultipartFormDataSerialization.Error.InputStreamReadFailed(failureReason)
+            } else {
+                break
+            }
+        }
+
+        inputStream.close()
+        inputStream.removeFromRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
+    }
+
+    private func writeFinalBoundaryDataForBodyPart(
+        bodyPart: BodyPart,
+        toOutputStream outputStream: NSOutputStream)
+        throws
+    {
+        if bodyPart.hasFinalBoundary {
+            return try writeData(finalBoundaryData(), toOutputStream: outputStream)
+        }
+    }
+
+    // MARK: - Private - Writing Buffered Data to Output Stream
+
+    private func writeData(data: NSData, toOutputStream outputStream: NSOutputStream) throws {
+        var buffer = [UInt8](count: data.length, repeatedValue: 0)
+        data.getBytes(&buffer, length: data.length)
+
+        return try writeBuffer(&buffer, toOutputStream: outputStream)
+    }
+
+    private func writeBuffer(inout buffer: [UInt8], toOutputStream outputStream: NSOutputStream) throws {
+        var bytesToWrite = buffer.count
+
+        while bytesToWrite > 0 {
+            if outputStream.hasSpaceAvailable {
+                let bytesWritten = outputStream.write(buffer, maxLength: bytesToWrite)
+
+                if let streamError = outputStream.streamError {
+                    throw streamError
+                }
+
+                if bytesWritten < 0 {
+                    let failureReason = "Failed to write to output stream: \(outputStream)"
+                    throw MultipartFormDataSerialization.Error.OutputStreamWriteFailed(failureReason)
+                }
+
+                bytesToWrite -= bytesWritten
+
+                if bytesToWrite > 0 {
+                    buffer = Array(buffer[bytesWritten..<buffer.count])
+                }
+            } else if let streamError = outputStream.streamError {
+                throw streamError
+            }
+        }
+    }
+
+    // MARK: - Private - Mime Type
+
+    private func mimeTypeForPathExtension(pathExtension: String) -> String {
+        if let
+            id = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension, nil)?.takeRetainedValue(),
+            contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?.takeRetainedValue()
+        {
+            return contentType as String
+        }
+
+        return "application/octet-stream"
+    }
+
+    // MARK: - Private - Content Headers
+
+    private func contentHeaders(name name: String) -> [String: String] {
+        return ["Content-Disposition": "form-data; name=\"\(name)\""]
+    }
+
+    private func contentHeaders(name name: String, mimeType: String) -> [String: String] {
+        return [
+            "Content-Disposition": "form-data; name=\"\(name)\"",
+            "Content-Type": "\(mimeType)"
+        ]
+    }
+
+    private func contentHeaders(name name: String, fileName: String, mimeType: String) -> [String: String] {
+        return [
+            "Content-Disposition": "form-data; name=\"\(name)\"; filename=\"\(fileName)\"",
+            "Content-Type": "\(mimeType)"
+        ]
+    }
+
+    // MARK: - Private - Boundary Encoding
+
+    private func initialBoundaryData() -> NSData {
+        return BoundaryGenerator.boundaryData(boundaryType: .Initial, boundary: boundary)
+    }
+
+    private func encapsulatedBoundaryData() -> NSData {
+        return BoundaryGenerator.boundaryData(boundaryType: .Encapsulated, boundary: boundary)
+    }
+
+    private func finalBoundaryData() -> NSData {
+        return BoundaryGenerator.boundaryData(boundaryType: .Final, boundary: boundary)
+    }
+
+    // MARK: - Private - Errors
+
+    private func setBodyPartError(error: ErrorType) {
+        if bodyPartError == nil {
+            bodyPartError = error
+        }
+    }
+}

--- a/APIKit/RequestBodyBuilder.swift
+++ b/APIKit/RequestBodyBuilder.swift
@@ -4,36 +4,27 @@ import Result
 public enum RequestBodyBuilder {
     case JSON(writingOptions: NSJSONWritingOptions)
     case URL(encoding: NSStringEncoding)
+    case MultipartFormData
     case Custom(contentTypeHeader: String, buildBodyFromObject: AnyObject throws -> NSData)
-    
-    public var contentTypeHeader: String {
-        switch self {
-        case .JSON:
-            return "application/json"
-            
-        case .URL:
-            return "application/x-www-form-urlencoded"
-            
-        case .Custom(let (type, _)):
-            return type
-        }
-    }
 
     /// - Throws: NSError, URLEncodedSerialization.Error, ErrorType
-    public func buildBodyFromObject(object: AnyObject) throws -> NSData {
+    public func buildBodyFromObject(object: AnyObject) throws -> (contentTypeHeader: String, body: NSData) {
         switch self {
         case .JSON(let writingOptions):
             // If isValidJSONObject(_:) is false, dataWithJSONObject(_:options:) throws NSException.
             guard NSJSONSerialization.isValidJSONObject(object) else {
                 throw NSError(domain: NSCocoaErrorDomain, code: 3840, userInfo: nil)
             }
-            return try NSJSONSerialization.dataWithJSONObject(object, options: writingOptions)
+            return ("application/json", try NSJSONSerialization.dataWithJSONObject(object, options: writingOptions))
 
         case .URL(let encoding):
-            return try URLEncodedSerialization.dataFromObject(object, encoding: encoding)
+            return ("application/x-www-form-urlencoded", try URLEncodedSerialization.dataFromObject(object, encoding: encoding))
 
-        case .Custom(let (_, buildBodyFromObject)):
-            return try buildBodyFromObject(object)
+        case .MultipartFormData:
+            let (boundary, body) = try MultipartFormDataSerialization.dataFromObject(object)
+            return ("multipart/form-data; boundary=\(boundary)", body)
+        case .Custom(let (contentTypeHeader, buildBodyFromObject)):
+            return (contentTypeHeader, try buildBodyFromObject(object))
         }
     }
 }

--- a/APIKit/RequestType.swift
+++ b/APIKit/RequestType.swift
@@ -100,8 +100,9 @@ public extension RequestType {
             
         default:
             do {
-                URLRequest.HTTPBody = try requestBodyBuilder.buildBodyFromObject(parameters)
-                URLRequest.setValue(requestBodyBuilder.contentTypeHeader, forHTTPHeaderField: "Content-Type")
+                let (contentTypeHeader, body) = try requestBodyBuilder.buildBodyFromObject(parameters)
+                URLRequest.HTTPBody = body
+                URLRequest.setValue(contentTypeHeader, forHTTPHeaderField: "Content-Type")
             } catch {
                 return .Failure(.RequestBodySerializationError(error))
             }


### PR DESCRIPTION
#108

I copied fundamental parts from [Alamofire](https://github.com/Alamofire/Alamofire) (Thanks Alamofire project! :pray: ) and added `MultipartFormDataSerialization` as a interface layer.

## How to use
```swift
struct PostImageRequest: RequestType {
    typealias Response = ImageReponse

    var imageFileURL: NSURL // "file://~/image.jpg"
    var imageData: NSData
    let requestBodyBuilder: RequestBodyBuilder = .MultipartFormData
    let method: HTTPMethod = .Post
    let path = "/api/image"

    var parameters: [String : AnyObject] {
        return [
            "image1" : imageFileURL, 
            "image2" : MultipartFormDataSerialization.Parameter(data: imageData, mimeType: "image/jpeg")
            "flag" : true
        ]
    }
}
```

`MultipartFormDataSerialization` supports `NSURL`,` NSData`,  `Bool`, `String`, `Int`, `Double` parameters.
It guesses MIME Type from a path extension (e.g. `.jpg`) in NSURL. If you want to add MIME Type manually, you should use `MultipartFormDataSerialization.Parameter`. 

## API Changes
I modified `RequestBodyBuilder`. 

removed
```swift
- public var contentTypeHeader: String
```
changed
```swift
- public func buildBodyFromObject(object: AnyObject) throws -> NSData
+ public func buildBodyFromObject(object: AnyObject) throws -> (contentTypeHeader: String, body: NSData)
```

To handle same boundary, `RequestBodyBuilder` was modified to create a header and a body simultaneously because `multipart/form-data` needs same boundary in both a content type header and a body. 
It seems not to effect ordinary users without RequestBodyBuilder.Custom users (anybody?).

## Discussion

I'm not satisfied with `MultipartFormDataSerialization.Parameter` because `MultipartFormDataSerialization` doesn't force request classes to use this class since parameters are typed as `[String : AnyObject]`. 
Thus, I suggest to move request parameter handling from RequestType to RequestBodyBuilder.  

My image:

```swift
struct PostImageRequest: RequestType {
   ...
    var requestBodyBuilder: RequestBodyBuilder {
        let params =  [
            ("image1", imageFileURL),
            ("image2",  RequestBodyBuilder.MultipartFormData.Parameter(data: imageData, mimeType: "image/jpeg")),
            ("flag", true)
        ]
        return RequestBodyBuilder.MultipartFormData(params)
    }
   ...
}

extension RequestBodyBuilder {
    struct MultipartFormData {
        init(parameters: [(String, MultipartFormDataParameter)]) { ... }
        init(parameters: [String : MultipartFormDataParameter]) { ... }
    }
}

protocol MultipartFormDataEncodable { }

extension RequestBodyBuilder.MultipartFormData {
    struct Parameter: MultipartFormDataEncodable {
        init(data: NSData, mimeType: String) {
            ...
        }
    }
}

extension NSURL: MultipartFormDataEncodable {}
...
```

I understand it needs breaking changes and hope @ishkawa will consider this suggestion in next major version :smile: 