### PR TITLE
Abstraction of backend

### DIFF
--- a/APIKit.xcodeproj/project.pbxproj
+++ b/APIKit.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		7F7E8F1B1C8AD4B1008A13A9 /* ResponseBodyParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7E8F111C8AD4B1008A13A9 /* ResponseBodyParser.swift */; };
 		7F7E8F1C1C8AD4B1008A13A9 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7E8F121C8AD4B1008A13A9 /* Session.swift */; };
 		7F7E8F1D1C8AD4B1008A13A9 /* URLEncodedSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7E8F131C8AD4B1008A13A9 /* URLEncodedSerialization.swift */; };
+		7F8EE4311C8C19EF00BDBAB1 /* NSURLSessionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8EE4301C8C19EF00BDBAB1 /* NSURLSessionAdapter.swift */; };
+		7F8EE4331C8C1A4900BDBAB1 /* SessionAdapterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8EE4321C8C1A4900BDBAB1 /* SessionAdapterType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -72,6 +74,8 @@
 		7F7E8F121C8AD4B1008A13A9 /* Session.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		7F7E8F131C8AD4B1008A13A9 /* URLEncodedSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLEncodedSerialization.swift; sourceTree = "<group>"; };
 		7F8ECDFD1B6A799E00234E04 /* Demo.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Demo.playground; sourceTree = "<group>"; };
+		7F8EE4301C8C19EF00BDBAB1 /* NSURLSessionAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLSessionAdapter.swift; sourceTree = "<group>"; };
+		7F8EE4321C8C1A4900BDBAB1 /* SessionAdapterType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionAdapterType.swift; sourceTree = "<group>"; };
 		CD5115241B1FFBA900514240 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD51152D1B1FFCC700514240 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OHHTTPStubs.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -163,6 +167,8 @@
 			isa = PBXGroup;
 			children = (
 				7F7E8F121C8AD4B1008A13A9 /* Session.swift */,
+				7F8EE4321C8C1A4900BDBAB1 /* SessionAdapterType.swift */,
+				7F8EE4301C8C19EF00BDBAB1 /* NSURLSessionAdapter.swift */,
 				7F7E8F101C8AD4B1008A13A9 /* RequestType.swift */,
 				7F7E8F0C1C8AD4B1008A13A9 /* HTTPMethod.swift */,
 				7F7E8F0A1C8AD4B1008A13A9 /* APIError.swift */,
@@ -294,6 +300,8 @@
 				7F7E8F181C8AD4B1008A13A9 /* MultipartFormDataSerialization.swift in Sources */,
 				7F7E8F1D1C8AD4B1008A13A9 /* URLEncodedSerialization.swift in Sources */,
 				7F7E8F191C8AD4B1008A13A9 /* RequestBodyBuilder.swift in Sources */,
+				7F8EE4331C8C1A4900BDBAB1 /* SessionAdapterType.swift in Sources */,
+				7F8EE4311C8C19EF00BDBAB1 /* NSURLSessionAdapter.swift in Sources */,
 				7F7E8F161C8AD4B1008A13A9 /* HTTPMethod.swift in Sources */,
 				7F3734581C8B245D006C5214 /* ResponseError.swift in Sources */,
 				7F7E8F141C8AD4B1008A13A9 /* APIError.swift in Sources */,

--- a/APIKit.xcodeproj/project.pbxproj
+++ b/APIKit.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		7F7E8F1D1C8AD4B1008A13A9 /* URLEncodedSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7E8F131C8AD4B1008A13A9 /* URLEncodedSerialization.swift */; };
 		7F8EE4311C8C19EF00BDBAB1 /* NSURLSessionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8EE4301C8C19EF00BDBAB1 /* NSURLSessionAdapter.swift */; };
 		7F8EE4331C8C1A4900BDBAB1 /* SessionAdapterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8EE4321C8C1A4900BDBAB1 /* SessionAdapterType.swift */; };
+		7FAC40341C8F2C900098C4B2 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FAC40331C8F2C900098C4B2 /* Box.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -76,6 +77,7 @@
 		7F8ECDFD1B6A799E00234E04 /* Demo.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Demo.playground; sourceTree = "<group>"; };
 		7F8EE4301C8C19EF00BDBAB1 /* NSURLSessionAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLSessionAdapter.swift; sourceTree = "<group>"; };
 		7F8EE4321C8C1A4900BDBAB1 /* SessionAdapterType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionAdapterType.swift; sourceTree = "<group>"; };
+		7FAC40331C8F2C900098C4B2 /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		CD5115241B1FFBA900514240 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD51152D1B1FFCC700514240 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OHHTTPStubs.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -178,6 +180,7 @@
 				7F7E8F111C8AD4B1008A13A9 /* ResponseBodyParser.swift */,
 				7F7E8F131C8AD4B1008A13A9 /* URLEncodedSerialization.swift */,
 				7F7E8F0E1C8AD4B1008A13A9 /* MultipartFormDataSerialization.swift */,
+				7FAC40331C8F2C900098C4B2 /* Box.swift */,
 				7F7E8F1E1C8AD4E6008A13A9 /* Supporting Files */,
 			);
 			path = Sources;
@@ -300,6 +303,7 @@
 				7F7E8F181C8AD4B1008A13A9 /* MultipartFormDataSerialization.swift in Sources */,
 				7F7E8F1D1C8AD4B1008A13A9 /* URLEncodedSerialization.swift in Sources */,
 				7F7E8F191C8AD4B1008A13A9 /* RequestBodyBuilder.swift in Sources */,
+				7FAC40341C8F2C900098C4B2 /* Box.swift in Sources */,
 				7F8EE4331C8C1A4900BDBAB1 /* SessionAdapterType.swift in Sources */,
 				7F8EE4311C8C19EF00BDBAB1 /* NSURLSessionAdapter.swift in Sources */,
 				7F7E8F161C8AD4B1008A13A9 /* HTTPMethod.swift in Sources */,

--- a/Sources/Box.swift
+++ b/Sources/Box.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+internal final class Box<T> {
+    let value: T
+
+    init(_ value: T) {
+        self.value = value
+    }
+}

--- a/Sources/NSURLSessionAdapter.swift
+++ b/Sources/NSURLSessionAdapter.swift
@@ -7,14 +7,6 @@ extension NSURLSessionTask: SessionTaskType {
 private var dataTaskResponseBufferKey = 0
 private var taskAssociatedObjectCompletionHandlerKey = 0
 
-private final class Box<T> {
-    let value: T
-
-    init(_ value: T) {
-        self.value = value
-    }
-}
-
 public class NSURLSessionAdapter: NSObject, SessionAdapterType, NSURLSessionDelegate {
     public var URLSession: NSURLSession!
     

--- a/Sources/NSURLSessionAdapter.swift
+++ b/Sources/NSURLSessionAdapter.swift
@@ -4,15 +4,31 @@ extension NSURLSessionTask: SessionTaskType {
 
 }
 
-public class NSURLSessionAdapter: SessionAdapterType {
-    public let URLSession: NSURLSession
+private var dataTaskResponseBufferKey = 0
+private var taskAssociatedObjectCompletionHandlerKey = 0
+
+private final class Box<T> {
+    let value: T
+
+    init(_ value: T) {
+        self.value = value
+    }
+}
+
+public class NSURLSessionAdapter: NSObject, SessionAdapterType, NSURLSessionDelegate {
+    public var URLSession: NSURLSession!
     
-    public init(URLSession: NSURLSession) {
-        self.URLSession = URLSession
+    public init(configuration: NSURLSessionConfiguration) {
+        super.init()
+        self.URLSession = NSURLSession(configuration: configuration, delegate: self, delegateQueue: nil)
     }
 
     public func resumedTaskWithURLRequest(URLRequest: NSURLRequest, handler: (NSData?, NSURLResponse?, NSError?) -> Void) -> SessionTaskType {
         let task = URLSession.dataTaskWithRequest(URLRequest, completionHandler: handler)
+
+        setBuffer(NSMutableData(), forTask: task)
+        setHandler(handler, forTask: task)
+
         task.resume()
 
         return task
@@ -24,7 +40,33 @@ public class NSURLSessionAdapter: SessionAdapterType {
                 + uploadTasks as [NSURLSessionTask]
                 + downloadTasks as [NSURLSessionTask]
 
-            handler(allTasks.map {$0})
+            handler(allTasks.map { $0 })
         }
+    }
+
+    private func setBuffer(buffer: NSMutableData, forTask task: NSURLSessionTask) {
+        objc_setAssociatedObject(task, &dataTaskResponseBufferKey, NSMutableData(), .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    private func bufferForTask(task: NSURLSessionTask) -> NSMutableData? {
+        return objc_getAssociatedObject(task, &dataTaskResponseBufferKey) as? NSMutableData
+    }
+
+    private func setHandler(handler: (NSData?, NSURLResponse?, NSError?) -> Void, forTask task: NSURLSessionTask) {
+        objc_setAssociatedObject(task, &taskAssociatedObjectCompletionHandlerKey, Box(handler), .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    private func handlerForTask(task: NSURLSessionTask) -> ((NSData?, NSURLResponse?, NSError?) -> Void)? {
+        return (objc_getAssociatedObject(task, &taskAssociatedObjectCompletionHandlerKey) as? Box<(NSData?, NSURLResponse?, NSError?) -> Void>)?.value
+    }
+
+    // MARK: NSURLSessionTaskDelegate
+    public func URLSession(session: NSURLSession, task: NSURLSessionTask, didCompleteWithError connectionError: NSError?) {
+        handlerForTask(task)?(bufferForTask(task), task.response, connectionError)
+    }
+
+    // MARK: NSURLSessionDataDelegate
+    public func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveData data: NSData) {
+        bufferForTask(dataTask)?.appendData(data)
     }
 }

--- a/Sources/NSURLSessionAdapter.swift
+++ b/Sources/NSURLSessionAdapter.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+extension NSURLSessionTask: SessionTaskType {
+
+}
+
+public class NSURLSessionAdapter: SessionAdapterType {
+    public let URLSession: NSURLSession
+    
+    public init(URLSession: NSURLSession) {
+        self.URLSession = URLSession
+    }
+
+    public func resumedTaskWithURLRequest(URLRequest: NSURLRequest, handler: (NSData?, NSURLResponse?, NSError?) -> Void) -> SessionTaskType {
+        let task = URLSession.dataTaskWithRequest(URLRequest, completionHandler: handler)
+        task.resume()
+
+        return task
+    }
+
+    public func getTasksWithHandler(handler: [SessionTaskType] -> Void) {
+        URLSession.getTasksWithCompletionHandler { dataTasks, uploadTasks, downloadTasks in
+            let allTasks = dataTasks as [NSURLSessionTask]
+                + uploadTasks as [NSURLSessionTask]
+                + downloadTasks as [NSURLSessionTask]
+
+            handler(allTasks.map {$0})
+        }
+    }
+}

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -1,15 +1,39 @@
 import Foundation
 import Result
 
+private var taskRequestKey = 0
+
+private final class Box<T> {
+    let value: T
+
+    init(_ value: T) {
+        self.value = value
+    }
+}
+
 public class Session {
-    public let URLSession: NSURLSession
-    
-    public init(URLSession: NSURLSession) {
-        self.URLSession = URLSession
+    public let adapter: SessionAdapterType
+
+    public init(adapter: SessionAdapterType) {
+        self.adapter = adapter
     }
 
-    // send request and build response object
-    public func sendRequest<T: RequestType>(request: T, handler: (Result<T.Response, APIError>) -> Void = {r in}) -> NSURLSessionDataTask? {
+    // Shared session for static methods
+    public static var sharedSession: Session = {
+        let URLSession = NSURLSession.sharedSession()
+        let adapter = NSURLSessionAdapter(URLSession: URLSession)
+        return Session(adapter: adapter)
+    }()
+
+    public static func sendRequest<T: RequestType>(request: T, handler: (Result<T.Response, APIError>) -> Void = {r in}) -> SessionTaskType? {
+        return sharedSession.sendRequest(request, handler: handler)
+    }
+    
+    public static func cancelRequest<T: RequestType>(requestType: T.Type, passingTest test: T -> Bool = { r in true }) {
+        sharedSession.cancelRequest(requestType, passingTest: test)
+    }
+
+    func sendRequest<T: RequestType>(request: T, handler: (Result<T.Response, APIError>) -> Void = {r in}) -> SessionTaskType? {
         let URLRequest: NSURLRequest
         do {
             URLRequest = try request.buildURLRequest()
@@ -20,16 +44,14 @@ public class Session {
             return nil
         }
 
-        let dataTask = URLSession.dataTaskWithRequest(URLRequest)
-        dataTask.request = Box(request)
-        dataTask.completionHandler = { data, URLResponse, error in
+        let task = adapter.resumedTaskWithURLRequest(URLRequest) { data, URLResponse, error in
             let result: Result<T.Response, APIError>
 
             switch (data, URLResponse, error) {
             case (_, _, let error?):
                 result = .Failure(.ConnectionError(error))
 
-            case (let data, let URLResponse as NSHTTPURLResponse, _):
+            case (let data?, let URLResponse as NSHTTPURLResponse, _):
                 do {
                     result = .Success(try request.parseData(data, URLResponse: URLResponse))
                 } catch {
@@ -45,156 +67,30 @@ public class Session {
             }
         }
 
-        dataTask.resume()
+        setRequest(request, forTask: task)
 
-        return dataTask
+        return task
     }
 
-    public func cancelRequest<T: RequestType>(requestType: T.Type, passingTest test: T -> Bool = { r in true }) {
-        URLSession.getTasksWithCompletionHandler { dataTasks, uploadTasks, downloadTasks in
-            let allTasks = dataTasks as [NSURLSessionTask]
-                + uploadTasks as [NSURLSessionTask]
-                + downloadTasks as [NSURLSessionTask]
-
-            allTasks.filter { task in
-                let request: T?
-                switch task {
-                case let x as NSURLSessionDataTask:
-                    request = x.request?.value as? T
-
-                case let x as NSURLSessionDownloadTask:
-                    request = x.request?.value as? T
-                    
-                default:
-                    request = nil
+    func cancelRequest<T: RequestType>(requestType: T.Type, passingTest test: T -> Bool = { r in true }) {
+        adapter.getTasksWithHandler { [weak self] tasks in
+            tasks
+                .filter { task in
+                    if let request = self?.requestForTask(task) as T? {
+                        return test(request)
+                    } else {
+                        return false
+                    }
                 }
-                
-                if let request = request {
-                    return test(request)
-                } else {
-                    return false
-                }
-            }.forEach { $0.cancel() }
-        }
-    }
-    
-    // Shared session for static methods
-    public static let sharedSession = Session(URLSession: NSURLSession(
-        configuration: NSURLSessionConfiguration.defaultSessionConfiguration(),
-        delegate: URLSessionDelegate(),
-        delegateQueue: nil
-    ))
-    
-    public static func sendRequest<T: RequestType>(request: T, handler: (Result<T.Response, APIError>) -> Void = {r in}) -> NSURLSessionDataTask? {
-        return sharedSession.sendRequest(request, handler: handler)
-    }
-    
-    public static func cancelRequest<T: RequestType>(requestType: T.Type, passingTest test: T -> Bool = { r in true }) {
-        sharedSession.cancelRequest(requestType, passingTest: test)
-    }
-}
-
-@available(*, unavailable, renamed="Session")
-public typealias API = Session
-
-extension Session {
-    @available(*, unavailable, message="Use separated Session instance instead.")
-    public static func sendRequest<T: RequestType>(request: T, URLSession: NSURLSession, handler: (Result<T.Response, APIError>) -> Void = {r in}) -> NSURLSessionDataTask? {
-        abort()
-    }
-    
-    @available(*, unavailable, message="Use separated Session instance instead.")
-    public static func cancelRequest<T: RequestType>(requestType: T.Type, URLSession: NSURLSession, passingTest test: T -> Bool = { r in true }) {
-        abort()
-    }
-}
-
-// MARK: - default implementation of URLSessionDelegate
-public class URLSessionDelegate: NSObject, NSURLSessionDelegate, NSURLSessionDataDelegate {
-    // MARK: NSURLSessionTaskDelegate
-    public func URLSession(session: NSURLSession, task: NSURLSessionTask, didCompleteWithError connectionError: NSError?) {
-        if let dataTask = task as? NSURLSessionDataTask {
-            dataTask.completionHandler?(dataTask.responseBuffer, dataTask.response, connectionError)
+                .forEach { $0.cancel() }
         }
     }
 
-    // MARK: NSURLSessionDataDelegate
-    public func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveData data: NSData) {
-        dataTask.responseBuffer.appendData(data)
+    private func setRequest<T: RequestType>(request: T, forTask task: SessionTaskType) {
+        objc_setAssociatedObject(task, &taskRequestKey, Box(request), .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
-    
-    public func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didBecomeDownloadTask downloadTask: NSURLSessionDownloadTask) {
-        downloadTask.request = dataTask.request
-    }
-}
 
-// Box<T> is still necessary internally to store struct into associated object
-private final class Box<T> {
-    let value: T
-    init(_ value: T) {
-        self.value = value
-    }
-}
-
-// MARK: - NSURLSessionTask extensions
-private var taskRequestKey = 0
-private var dataTaskResponseBufferKey = 0
-private var dataTaskCompletionHandlerKey = 0
-
-private extension NSURLSessionDataTask {
-    // `var request: RequestType?` is not available in Swift 2.0
-    // ("protocol can only be used as a generic constraint")
-    private var request: Box<Any>? {
-        get {
-            return objc_getAssociatedObject(self, &taskRequestKey) as? Box<Any>
-        }
-        
-        set {
-            if let value = newValue {
-                objc_setAssociatedObject(self, &taskRequestKey, value, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            } else {
-                objc_setAssociatedObject(self, &taskRequestKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            }
-        }
-    }
-    
-    private var responseBuffer: NSMutableData {
-        if let responseBuffer = objc_getAssociatedObject(self, &dataTaskResponseBufferKey) as? NSMutableData {
-            return responseBuffer
-        } else {
-            let responseBuffer = NSMutableData()
-            objc_setAssociatedObject(self, &dataTaskResponseBufferKey, responseBuffer, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            return responseBuffer
-        }
-    }
-    
-    private var completionHandler: ((NSData, NSURLResponse?, NSError?) -> Void)? {
-        get {
-            return (objc_getAssociatedObject(self, &dataTaskCompletionHandlerKey) as? Box<(NSData, NSURLResponse?, NSError?) -> Void>)?.value
-        }
-        
-        set {
-            if let value = newValue  {
-                objc_setAssociatedObject(self, &dataTaskCompletionHandlerKey, Box(value), .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            } else {
-                objc_setAssociatedObject(self, &dataTaskCompletionHandlerKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            }
-        }
-    }
-}
-
-private extension NSURLSessionDownloadTask {
-    private var request: Box<Any>? {
-        get {
-            return objc_getAssociatedObject(self, &taskRequestKey) as? Box<Any>
-        }
-        
-        set {
-            if let value = newValue {
-                objc_setAssociatedObject(self, &taskRequestKey, value, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            } else {
-                objc_setAssociatedObject(self, &taskRequestKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            }
-        }
+    private func requestForTask<T: RequestType>(task: SessionTaskType) -> T? {
+        return (objc_getAssociatedObject(task, &taskRequestKey) as? Box<T>)?.value
     }
 }

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -3,14 +3,6 @@ import Result
 
 private var taskRequestKey = 0
 
-private final class Box<T> {
-    let value: T
-
-    init(_ value: T) {
-        self.value = value
-    }
-}
-
 public class Session {
     public let adapter: SessionAdapterType
 

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -20,8 +20,8 @@ public class Session {
 
     // Shared session for static methods
     public static var sharedSession: Session = {
-        let URLSession = NSURLSession.sharedSession()
-        let adapter = NSURLSessionAdapter(URLSession: URLSession)
+        let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
+        let adapter = NSURLSessionAdapter(configuration: configuration)
         return Session(adapter: adapter)
     }()
 

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -33,7 +33,7 @@ public class Session {
         sharedSession.cancelRequest(requestType, passingTest: test)
     }
 
-    func sendRequest<T: RequestType>(request: T, handler: (Result<T.Response, APIError>) -> Void = {r in}) -> SessionTaskType? {
+    public func sendRequest<T: RequestType>(request: T, handler: (Result<T.Response, APIError>) -> Void = {r in}) -> SessionTaskType? {
         let URLRequest: NSURLRequest
         do {
             URLRequest = try request.buildURLRequest()
@@ -72,7 +72,7 @@ public class Session {
         return task
     }
 
-    func cancelRequest<T: RequestType>(requestType: T.Type, passingTest test: T -> Bool = { r in true }) {
+    public func cancelRequest<T: RequestType>(requestType: T.Type, passingTest test: T -> Bool = { r in true }) {
         adapter.getTasksWithHandler { [weak self] tasks in
             tasks
                 .filter { task in

--- a/Sources/SessionAdapterType.swift
+++ b/Sources/SessionAdapterType.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public protocol SessionTaskType: class {
+    func cancel()
+}
+
+public protocol SessionAdapterType {
+    func resumedTaskWithURLRequest(URLRequest: NSURLRequest, handler: (NSData?, NSURLResponse?, NSError?) -> Void) -> SessionTaskType
+    func getTasksWithHandler(handler: [SessionTaskType] -> Void)
+}


### PR DESCRIPTION
There're some feature requests that Alamofire provides, for example #129 and #121, but I would like to keep APIKit as simple as possible. To satisfy the both needs, I decided to make the backend abstract. On the new architecture, we can build `Session` both on `NSURLSession` and `Alamofire.Manager`.

### SessionAdapterType

 This PR introduces 2 new protocols, `SessionAdapterType` and `SessionTaskType`:

```swift
public protocol SessionAdapterType {
    func resumedTaskWithURLRequest(URLRequest: NSURLRequest, handler: (NSData?, NSURLResponse?, NSError?) -> Void) -> SessionTaskType
    func getTasksWithHandler(handler: [SessionTaskType] -> Void)
}

public protocol SessionTaskType: class {
    func cancel()
}
```

`SessionAdapterType` provides an interface to get `(NSData?, NSURLResponse?, NSError?)` from `NSURLRequest` and returns `SessionTaskType` for cancellation. Although the protocols are simple abstraction of `NSURLSession` and `NSURLSessionTask`, I think many HTTP client library can conform to them.

### How Session works with SessionAdapterType

To use `SessionAdapterType` in `Session`, parameters of `Session.init()` are changed as below:

```swift
public class Session {
    public let adapter: SessionAdapterType

    public init(adapter: SessionAdapterType) {
        self.adapter = adapter
    }

    ...
}
```

Once it is initialized with a session adapter, it sends `NSURLRequest` and receives `(NSData?, NSURLResponse?, NSError?)` via the interfaces which are defined in `SessionAdapterType`.

```swift
func sendRequest<T: RequestType>(request: T, handler: (Result<T.Response, APIError>) -> Void = {r in}) -> SessionTaskType? {
    let URLRequest: NSURLRequest = ...
    let task = adapter.resumedTaskWithURLRequest(URLRequest) { data, URLResponse, error in
        ...
    }
}
```