### PR TITLE
Remove type constraint from example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ struct GetRateLimitRequest: GitHubRequest {
 Additionally, you can provide default implementation of `responseFromObject(_:URLResponse:)` if `Response` typealias of a request type conforms to `Decodable`.
 
 ```swift
-extension GitHubRequest where Self.Response: Decodable, Self.Response == Self.Response.DecodedType {
+extension GitHubRequest where Self.Response: Decodable {
     func responseFromObject(object: AnyObject, URLResponse: NSHTTPURLResponse) -> Self.Response? {
         return try? decode(object)
     }


### PR DESCRIPTION
related #151 

Since Himotoki 2.0, `Decodable.DecodedType` has been removed https://github.com/ikesyo/Himotoki/blob/204e79dcef75595cb0a1cec4a53a82e6fdaf9e40/Sources/Decodable.swift#L9-L12 
so the consistent `Self.Response == Self.Response.DecodedType` doesnt work.