### PR TITLE
Move building backend request like NSURLRequest to SessionAdapterType

### DIFF
--- a/Sources/Error/RequestError.swift
+++ b/Sources/Error/RequestError.swift
@@ -3,5 +3,6 @@ import Foundation
 /// `RequestError` represents a common error that occurs while building `NSURLRequest` from `RequestType`.
 enum RequestError: ErrorType {
     case InvalidBaseURL(NSURL)
+    case InvalidURLComponents(NSURLComponents)
     case UnexpectedURLRequest(NSURLRequest)
 }

--- a/Sources/Error/SessionTaskError.swift
+++ b/Sources/Error/SessionTaskError.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// `SessionTaskError` represents an error that occurs while task for a request.
 public enum SessionTaskError: ErrorType {
-    /// Error of `NSURLSession`.
-    case ConnectionError(NSError)
+    /// Error of session backend such as `NSURLSession`.
+    case ConnectionError(ErrorType)
 
     /// Error while creating `NSURLReqeust` from `Request`.
     case RequestError(ErrorType)

--- a/Sources/RequestType.swift
+++ b/Sources/RequestType.swift
@@ -36,10 +36,8 @@ public protocol RequestType {
     /// will be computed from `parameters` using `JSONBodyParameters`.
     var bodyParameters: BodyParametersType? { get }
 
-    /// The HTTP header fields. In addition to fields defined in this property, `Accept` and `Content-Type`
-    /// fields provided by `dataParser` and `bodyParameters` will be added in `headerFields`.
-    /// If you define `Accept` and `Content-Type` in this property, the values in this property are preferred.
-    var additionalHeaderFields: [String: String] { get }
+    /// The HTTP header fields.
+    var headerFields: [String: String] { get }
 
     /// The parser object that states `Content-Type` to accept and parses response body.
     var dataParser: DataParserType { get }
@@ -76,22 +74,8 @@ public extension RequestType {
         return JSONBodyParameters(JSONObject: parameters)
     }
 
-    public var additionalHeaderFields: [String: String] {
-        return [:]
-    }
-
     public var headerFields: [String: String] {
-        var headerFields = additionalHeaderFields
-
-        if let bodyContentType = bodyParameters?.contentType where headerFields["ContentType"] == nil {
-            headerFields["Content-Type"] = bodyContentType
-        }
-
-        if let acceptContentType = dataParser.contentType where headerFields["Accept"] == nil {
-            headerFields["Accept"] = acceptContentType
-        }
-
-        return headerFields
+        return [:]
     }
 
     public var dataParser: DataParserType {

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -55,7 +55,7 @@ public class Session {
     /// - returns: The new session task.
     public func sendRequest<Request: RequestType>(request: Request, callbackQueue: CallbackQueue? = nil, handler: (Result<Request.Response, SessionTaskError>) -> Void = {r in}) -> SessionTaskType? {
         let callbackQueue = callbackQueue ?? self.callbackQueue
-        let adapterHandler = { (data: NSData?, URLResponse: NSURLResponse?, error: NSError?) -> Void in
+        let adapterHandler = { (data: NSData?, URLResponse: NSURLResponse?, error: ErrorType?) -> Void in
             let result: Result<Request.Response, SessionTaskError>
 
             switch (data, URLResponse, error) {

--- a/Sources/SessionAdapterType/NSURLSessionAdapter.swift
+++ b/Sources/SessionAdapterType/NSURLSessionAdapter.swift
@@ -28,8 +28,6 @@ public class NSURLSessionAdapter: NSObject, SessionAdapterType, NSURLSessionDele
         let URLRequest = NSMutableURLRequest()
 
         if let bodyParameters = request.bodyParameters {
-            URLRequest.setValue(bodyParameters.contentType, forHTTPHeaderField: "Content-Type")
-
             switch try bodyParameters.buildEntity() {
             case .Data(let data):
                 URLRequest.HTTPBody = data
@@ -41,9 +39,8 @@ public class NSURLSessionAdapter: NSObject, SessionAdapterType, NSURLSessionDele
 
         URLRequest.URL = try request.buildURL()
         URLRequest.HTTPMethod = request.method.rawValue
-        URLRequest.setValue(request.dataParser.contentType, forHTTPHeaderField: "Accept")
-        
-        request.HTTPHeaderFields.forEach { key, value in
+
+        request.headerFields.forEach { key, value in
             URLRequest.setValue(value, forHTTPHeaderField: key)
         }
 

--- a/Sources/SessionAdapterType/NSURLSessionAdapter.swift
+++ b/Sources/SessionAdapterType/NSURLSessionAdapter.swift
@@ -25,7 +25,7 @@ public class NSURLSessionAdapter: NSObject, SessionAdapterType, NSURLSessionDele
         self.URLSession = NSURLSession(configuration: configuration, delegate: self, delegateQueue: nil)
     }
 
-    public func createTaskWithRequest<Request : RequestType>(request: Request, handler: (NSData?, NSURLResponse?, NSError?) -> Void) throws -> SessionTaskType {
+    public func createTaskWithRequest<Request : RequestType>(request: Request, handler: (NSData?, NSURLResponse?, ErrorType?) -> Void) throws -> SessionTaskType {
         let URLRequest = NSMutableURLRequest()
 
         if let bodyParameters = request.bodyParameters {

--- a/Sources/SessionAdapterType/NSURLSessionAdapter.swift
+++ b/Sources/SessionAdapterType/NSURLSessionAdapter.swift
@@ -27,17 +27,6 @@ public class NSURLSessionAdapter: NSObject, SessionAdapterType, NSURLSessionDele
 
     public func createTaskWithRequest<Request : RequestType>(request: Request, handler: (NSData?, NSURLResponse?, ErrorType?) -> Void) throws -> SessionTaskType {
         let URLRequest = NSMutableURLRequest()
-
-        if let bodyParameters = request.bodyParameters {
-            switch try bodyParameters.buildEntity() {
-            case .Data(let data):
-                URLRequest.HTTPBody = data
-
-            case .InputStream(let inputStream):
-                URLRequest.HTTPBodyStream = inputStream
-            }
-        }
-
         URLRequest.URL = try request.buildURL()
         URLRequest.HTTPMethod = request.method.rawValue
 

--- a/Sources/SessionAdapterType/NSURLSessionAdapter.swift
+++ b/Sources/SessionAdapterType/NSURLSessionAdapter.swift
@@ -76,7 +76,7 @@ public class NSURLSessionAdapter: NSObject, SessionAdapterType, NSURLSessionDele
 
     // MARK: Associated objects
     private func setBuffer(buffer: NSMutableData, forTask task: NSURLSessionTask) {
-        objc_setAssociatedObject(task, &dataTaskResponseBufferKey, NSMutableData(), .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(task, &dataTaskResponseBufferKey, buffer, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
 
     private func bufferForTask(task: NSURLSessionTask) -> NSMutableData? {

--- a/Sources/SessionAdapterType/NSURLSessionAdapter.swift
+++ b/Sources/SessionAdapterType/NSURLSessionAdapter.swift
@@ -34,8 +34,17 @@ public class NSURLSessionAdapter: NSObject, SessionAdapterType, NSURLSessionDele
             URLRequest.setValue(value, forHTTPHeaderField: key)
         }
 
+        let bodyParameters = request.bodyParameters
+        if let bodyContentType = bodyParameters?.contentType where URLRequest.valueForHTTPHeaderField("Content-Type") == nil {
+            URLRequest.setValue(bodyContentType, forHTTPHeaderField: "Content-Type")
+        }
+
+        if let acceptContentType = request.dataParser.contentType where URLRequest.valueForHTTPHeaderField("Accept") == nil {
+            URLRequest.setValue(acceptContentType, forHTTPHeaderField: "Accept")
+        }
+
         let task: NSURLSessionTask
-        switch try request.bodyParameters?.buildEntity() {
+        switch try bodyParameters?.buildEntity() {
         case .Data(let data)?:
             task = URLSession.uploadTaskWithRequest(URLRequest, fromData: data)
 

--- a/Sources/SessionAdapterType/SessionAdapterType.swift
+++ b/Sources/SessionAdapterType/SessionAdapterType.swift
@@ -11,7 +11,7 @@ public protocol SessionTaskType: class {
 /// with `Session`.
 public protocol SessionAdapterType {
     /// Returns resumed instance that conforms to `SessionTaskType`. `handler` must be called after success or failure.
-    func createTaskWithRequest<Request: RequestType>(request: Request, handler: (NSData?, NSURLResponse?, NSError?) -> Void) throws -> SessionTaskType
+    func createTaskWithRequest<Request: RequestType>(request: Request, handler: (NSData?, NSURLResponse?, ErrorType?) -> Void) throws -> SessionTaskType
 
     /// Collects tasks from backend networking stack. `handler` must be called after collecting.
     func getTasksWithHandler(handler: [SessionTaskType] -> Void)

--- a/Sources/SessionAdapterType/SessionAdapterType.swift
+++ b/Sources/SessionAdapterType/SessionAdapterType.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// `SessionTaskType` protocol represents a task for a request.
 public protocol SessionTaskType: class {
+    func resume()
     func cancel()
 }
 
@@ -10,7 +11,7 @@ public protocol SessionTaskType: class {
 /// with `Session`.
 public protocol SessionAdapterType {
     /// Returns resumed instance that conforms to `SessionTaskType`. `handler` must be called after success or failure.
-    func resumedTaskWithURLRequest(URLRequest: NSURLRequest, handler: (NSData?, NSURLResponse?, NSError?) -> Void) -> SessionTaskType
+    func createTaskWithRequest<Request: RequestType>(request: Request, handler: (NSData?, NSURLResponse?, NSError?) -> Void) throws -> SessionTaskType
 
     /// Collects tasks from backend networking stack. `handler` must be called after collecting.
     func getTasksWithHandler(handler: [SessionTaskType] -> Void)

--- a/Tests/APIKit/RequestTypeTests.swift
+++ b/Tests/APIKit/RequestTypeTests.swift
@@ -4,59 +4,22 @@ import APIKit
 class RequestTypeTests: XCTestCase {
     func testJapanesesQueryParameters() {
         let request = TestRequest(parameters: ["q": "こんにちは"])
-        let URLRequest = try? request.buildURLRequest()
-        XCTAssertEqual(URLRequest?.URL?.query, "q=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF")
+        let URL = try? request.buildURL()
+        XCTAssertEqual(URL?.query, "q=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF")
     }
     
     func testSymbolQueryParameters() {
         let request = TestRequest(parameters: ["q": "!\"#$%&'()0=~|`{}*+<>?/_"])
-        let URLRequest = try? request.buildURLRequest()
-        XCTAssertEqual(URLRequest?.URL?.query, "q=%21%22%23%24%25%26%27%28%290%3D~%7C%60%7B%7D%2A%2B%3C%3E?/_")
+        let URL = try? request.buildURL()
+        XCTAssertEqual(URL?.query, "q=%21%22%23%24%25%26%27%28%290%3D~%7C%60%7B%7D%2A%2B%3C%3E?/_")
     }
 
     func testNullQueryParameters() {
         let request = TestRequest(parameters: ["null": NSNull()])
-        let URLRequest = try? request.buildURLRequest()
-        XCTAssertEqual(URLRequest?.URL?.query, "null")
+        let URL = try? request.buildURL()
+        XCTAssertEqual(URL?.query, "null")
     }
     
-    func testHTTPHeaderFields() {
-        let request = TestRequest(HTTPHeaderFields: ["Foo": "f", "Accept": "a", "Content-Type": "c"])
-        let URLReqeust = try? request.buildURLRequest()
-        XCTAssertEqual(URLReqeust?.valueForHTTPHeaderField("Foo"), "f")
-        XCTAssertEqual(URLReqeust?.valueForHTTPHeaderField("Accept"), "a")
-        XCTAssertEqual(URLReqeust?.valueForHTTPHeaderField("Content-Type"), "c")
-    }
-
-    func testPOSTJSONRequest() {
-        let parameters: [AnyObject] = [
-            ["id": "1"],
-            ["id": "2"],
-            ["hello", "yellow"]
-        ]
-
-        let request = TestRequest(method: .POST, parameters: parameters)
-        XCTAssert(request.parameters?.count == 3)
-
-        let URLRequest = try? request.buildURLRequest()
-        XCTAssertNotNil(URLRequest?.HTTPBody)
-
-        let json = URLRequest?.HTTPBody.flatMap { try? NSJSONSerialization.JSONObjectWithData($0, options: []) } as? [AnyObject]
-        XCTAssertEqual(json?.count, 3)
-        XCTAssertEqual(json?[0]["id"], "1")
-        XCTAssertEqual(json?[1]["id"], "2")
-
-        let array = json?[2] as? [String]
-        XCTAssertEqual(array?[0], "hello")
-        XCTAssertEqual(array?[1], "yellow")
-    }
-
-    func testPOSTInvalidJSONRequest() {
-        let request = TestRequest(method: .POST, parameters: "foo")
-        let URLRequest = try? request.buildURLRequest()
-        XCTAssertNil(URLRequest?.HTTPBody)
-    }
-
     func testBuildURL() {
         // MARK: - baseURL = https://example.com
         XCTAssertEqual(

--- a/Tests/APIKit/SessionAdapterType/NSURLSessionAdapterTests.swift
+++ b/Tests/APIKit/SessionAdapterType/NSURLSessionAdapterTests.swift
@@ -28,6 +28,42 @@ class NSURLSessionAdapterTests: XCTestCase {
         super.tearDown()
     }
 
+    func testPOSTJSONRequest() {
+        let parameters: [AnyObject] = [
+            ["id": "1"],
+            ["id": "2"],
+            ["hello", "yellow"]
+        ]
+
+        let request = TestRequest(method: .POST, parameters: parameters)
+        XCTAssert(request.parameters?.count == 3)
+
+        let sessionTask = try? session.adapter.createTaskWithRequest(request, handler: { _ in })
+        let URLSessionTask = sessionTask.flatMap { $0 as? NSURLSessionTask }
+        let URLRequest = URLSessionTask?.currentRequest
+        XCTAssertNotNil(URLRequest?.HTTPBody)
+        XCTAssertEqual(URLRequest?.valueForHTTPHeaderField("Content-Type"), "application/json")
+
+        let json = URLRequest?.HTTPBody.flatMap { try? NSJSONSerialization.JSONObjectWithData($0, options: []) } as? [AnyObject]
+        XCTAssertEqual(json?.count, 3)
+        XCTAssertEqual(json?[0]["id"], "1")
+        XCTAssertEqual(json?[1]["id"], "2")
+
+        let array = json?[2] as? [String]
+        XCTAssertEqual(array?[0], "hello")
+        XCTAssertEqual(array?[1], "yellow")
+    }
+
+    func testPOSTInvalidJSONRequest() {
+        let request = TestRequest(method: .POST, parameters: "Not a JSON object")
+        do {
+            try session.adapter.createTaskWithRequest(request, handler: { _ in })
+            XCTFail()
+        } catch {
+
+        }
+    }
+
     // MARK: - integration tests
     func testSuccess() {
         let dictionary = ["key": "value"]

--- a/Tests/APIKit/SessionAdapterType/NSURLSessionAdapterTests.swift
+++ b/Tests/APIKit/SessionAdapterType/NSURLSessionAdapterTests.swift
@@ -112,7 +112,7 @@ class NSURLSessionAdapterTests: XCTestCase {
                 
             case .Failure(let error):
                 switch error {
-                case .ConnectionError(let error):
+                case .ConnectionError(let error as NSError):
                     XCTAssertEqual(error.domain, NSURLErrorDomain)
 
                 default:

--- a/Tests/APIKit/SessionAdapterType/NSURLSessionAdapterTests.swift
+++ b/Tests/APIKit/SessionAdapterType/NSURLSessionAdapterTests.swift
@@ -41,17 +41,8 @@ class NSURLSessionAdapterTests: XCTestCase {
         let sessionTask = try? session.adapter.createTaskWithRequest(request, handler: { _ in })
         let URLSessionTask = sessionTask.flatMap { $0 as? NSURLSessionTask }
         let URLRequest = URLSessionTask?.currentRequest
-        XCTAssertNotNil(URLRequest?.HTTPBody)
         XCTAssertEqual(URLRequest?.valueForHTTPHeaderField("Content-Type"), "application/json")
-
-        let json = URLRequest?.HTTPBody.flatMap { try? NSJSONSerialization.JSONObjectWithData($0, options: []) } as? [AnyObject]
-        XCTAssertEqual(json?.count, 3)
-        XCTAssertEqual(json?[0]["id"], "1")
-        XCTAssertEqual(json?[1]["id"], "2")
-
-        let array = json?[2] as? [String]
-        XCTAssertEqual(array?[0], "hello")
-        XCTAssertEqual(array?[1], "yellow")
+        XCTAssert(URLSessionTask is NSURLSessionUploadTask)
     }
 
     func testPOSTInvalidJSONRequest() {

--- a/Tests/APIKit/SessionTests.swift
+++ b/Tests/APIKit/SessionTests.swift
@@ -86,7 +86,7 @@ class SessionTests: XCTestCase {
         
         session.sendRequest(request) { result in
             if case .Failure(let error) = result,
-               case .ConnectionError(let connectionError) = error {
+               case .ConnectionError(let connectionError as NSError) = error {
                 XCTAssertEqual(connectionError.code, 0)
             } else {
                 XCTFail()

--- a/Tests/APIKit/TestComponents/TestRequest.swift
+++ b/Tests/APIKit/TestComponents/TestRequest.swift
@@ -2,12 +2,12 @@ import Foundation
 import APIKit
 
 struct TestRequest: RequestType {
-    static func URLOf(baseURL baseURL: String = "https://example.com", path: String = "/", method: HTTPMethod = .GET, parameters: AnyObject? = [:], HTTPHeaderFields: [String: String] = [:]) -> NSURL? {
+    static func URLOf(baseURL baseURL: String = "https://example.com", path: String = "/", method: HTTPMethod = .GET, parameters: AnyObject? = [:], headerFields: [String: String] = [:]) -> NSURL? {
         guard let baseURL = NSURL(string: baseURL) else {
             return nil
         }
 
-        let request = TestRequest(baseURL: baseURL, path: path, method: method, parameters: parameters, HTTPHeaderFields: HTTPHeaderFields)
+        let request = TestRequest(baseURL: baseURL, path: path, method: method, parameters: parameters, headerFields: headerFields)
 
         return try? request.buildURL()
     }
@@ -15,19 +15,19 @@ struct TestRequest: RequestType {
     // MARK: RequestType
     typealias Response = AnyObject
 
-    init(baseURL: NSURL = NSURL(string: "https://example.com")!, path: String = "/", method: HTTPMethod = .GET, parameters: AnyObject? = [:], HTTPHeaderFields: [String: String] = [:]) {
+    init(baseURL: NSURL = NSURL(string: "https://example.com")!, path: String = "/", method: HTTPMethod = .GET, parameters: AnyObject? = [:], headerFields: [String: String] = [:]) {
         self.baseURL = baseURL
         self.path = path
         self.method = method
         self.parameters = parameters
-        self.HTTPHeaderFields = HTTPHeaderFields
+        self.headerFields = headerFields
     }
 
     let baseURL: NSURL
     let method: HTTPMethod
     let path: String
     let parameters: AnyObject?
-    let HTTPHeaderFields: [String: String]
+    let headerFields: [String: String]
 
     func responseFromObject(object: AnyObject, URLResponse: NSHTTPURLResponse) throws -> Response {
         return object

--- a/Tests/APIKit/TestComponents/TestRequest.swift
+++ b/Tests/APIKit/TestComponents/TestRequest.swift
@@ -8,9 +8,8 @@ struct TestRequest: RequestType {
         }
 
         let request = TestRequest(baseURL: baseURL, path: path, method: method, parameters: parameters, HTTPHeaderFields: HTTPHeaderFields)
-        let URLRequest = try? request.buildURLRequest()
 
-        return URLRequest?.URL
+        return try? request.buildURL()
     }
 
     // MARK: RequestType

--- a/Tests/APIKit/TestComponents/TestSessionAdapter.swift
+++ b/Tests/APIKit/TestComponents/TestSessionAdapter.swift
@@ -7,7 +7,6 @@ class TestSessionAdapter: SessionAdapterType {
     var error: NSError?
 
     var tasks = [TestSessionTask]()
-    var responseTime = NSTimeInterval(0.05)
 
     init(data: NSData? = NSData(), URLResponse: NSURLResponse? = NSHTTPURLResponse(URL: NSURL(), statusCode: 200, HTTPVersion: nil, headerFields: nil), error: NSError? = nil) {
         self.data = data
@@ -15,25 +14,18 @@ class TestSessionAdapter: SessionAdapterType {
         self.error = error
     }
 
-    func resumedTaskWithURLRequest(URLRequest: NSURLRequest, handler: (NSData?, NSURLResponse?, NSError?) -> Void) -> SessionTaskType {
-        let task = TestSessionTask(data: data, URLResponse: URLResponse, error: error) { [weak self] task in
+    func createTaskWithRequest<Request : RequestType>(request: Request, handler: (NSData?, NSURLResponse?, NSError?) -> Void) throws -> SessionTaskType {
+        let task = TestSessionTask(data: data, URLResponse: URLResponse, error: error) { [weak self] task, completed in
+            if completed {
+                handler(task.data, task.URLResponse, task.error)
+            }
+
             if let index = self?.tasks.indexOf({ $0 === task }) {
                 self?.tasks.removeAtIndex(index)
             }
         }
 
         tasks.append(task)
-
-        let time = dispatch_time(DISPATCH_TIME_NOW, Int64(responseTime * NSTimeInterval(NSEC_PER_SEC)))
-        let queue = dispatch_get_main_queue()
-
-        dispatch_after(time, queue) { [weak self] in
-            handler(task.data, task.URLResponse, task.error)
-
-            if let index = self?.tasks.indexOf({ $0 === task }) {
-                self?.tasks.removeAtIndex(index)
-            }
-        }
 
         return task
     }

--- a/Tests/APIKit/TestComponents/TestSessionAdapter.swift
+++ b/Tests/APIKit/TestComponents/TestSessionAdapter.swift
@@ -4,17 +4,17 @@ import APIKit
 class TestSessionAdapter: SessionAdapterType {
     var data: NSData?
     var URLResponse: NSURLResponse?
-    var error: NSError?
+    var error: ErrorType?
 
     var tasks = [TestSessionTask]()
 
-    init(data: NSData? = NSData(), URLResponse: NSURLResponse? = NSHTTPURLResponse(URL: NSURL(), statusCode: 200, HTTPVersion: nil, headerFields: nil), error: NSError? = nil) {
+    init(data: NSData? = NSData(), URLResponse: NSURLResponse? = NSHTTPURLResponse(URL: NSURL(), statusCode: 200, HTTPVersion: nil, headerFields: nil), error: ErrorType? = nil) {
         self.data = data
         self.URLResponse = URLResponse
         self.error = error
     }
 
-    func createTaskWithRequest<Request : RequestType>(request: Request, handler: (NSData?, NSURLResponse?, NSError?) -> Void) throws -> SessionTaskType {
+    func createTaskWithRequest<Request : RequestType>(request: Request, handler: (NSData?, NSURLResponse?, ErrorType?) -> Void) throws -> SessionTaskType {
         let task = TestSessionTask(data: data, URLResponse: URLResponse, error: error) { [weak self] task, completed in
             if completed {
                 handler(task.data, task.URLResponse, task.error)

--- a/Tests/APIKit/TestComponents/TestSessionTask.swift
+++ b/Tests/APIKit/TestComponents/TestSessionTask.swift
@@ -8,12 +8,12 @@ class TestSessionTask: SessionTaskType {
 
     var data: NSData?
     var URLResponse: NSURLResponse?
-    var error: NSError?
+    var error: ErrorType?
     var handler: (TestSessionTask, Bool) -> Void
 
     var responseTime = NSTimeInterval(0.05)
 
-    init(data: NSData?, URLResponse: NSURLResponse?, error: NSError?, handler: (TestSessionTask, Bool) -> Void) {
+    init(data: NSData?, URLResponse: NSURLResponse?, error: ErrorType?, handler: (TestSessionTask, Bool) -> Void) {
         self.data = data
         self.URLResponse = URLResponse
         self.error = error

--- a/Tests/APIKit/TestComponents/TestSessionTask.swift
+++ b/Tests/APIKit/TestComponents/TestSessionTask.swift
@@ -9,17 +9,28 @@ class TestSessionTask: SessionTaskType {
     var data: NSData?
     var URLResponse: NSURLResponse?
     var error: NSError?
-    var cancelHandler: (TestSessionTask) -> Void
+    var handler: (TestSessionTask, Bool) -> Void
 
-    init(data: NSData?, URLResponse: NSURLResponse?, error: NSError?, cancelHandler: (TestSessionTask) -> Void) {
+    var responseTime = NSTimeInterval(0.05)
+
+    init(data: NSData?, URLResponse: NSURLResponse?, error: NSError?, handler: (TestSessionTask, Bool) -> Void) {
         self.data = data
         self.URLResponse = URLResponse
         self.error = error
-        self.cancelHandler = cancelHandler
+        self.handler = handler
+    }
+
+    func resume() {
+        let time = dispatch_time(DISPATCH_TIME_NOW, Int64(responseTime * NSTimeInterval(NSEC_PER_SEC)))
+        let queue = dispatch_get_main_queue()
+
+        dispatch_after(time, queue) {
+            self.handler(self, true)
+        }
     }
 
     func cancel() {
         error = Error.Cancelled as NSError
-        cancelHandler(self)
+        handler(self, false)
     }
 }


### PR DESCRIPTION
In NSURLSession, entire behavior of HTTP/HTTPS request is defined by combination of NSURLRequest, NSURLSessionTask and NSURLSessionConfiguration. In current 2.0 implementation, RequestType expresses HTTP/HTTPS request in NSURLRequest only, so some features of NSURLSession is unavailable. For instance, `uploadTaskWithStreamedRequest(_:)` and `uploadTaskWithRequest(_:fromData)`.

To remove the limitation, I moved responsibility of building backend request like NSURLRequest to SessionAdapterType. In the new implementation, NSURLSessionAdapter can express requests combining NSURLRequest and NSURLSessionTask.

## Changes

#### RequestType

- [**Removed**] `buildURLRequest()`
- [**Added**] `buildURL()`
- [**Removed**] `HTTPHeaderFields`
- [**Added**] `headerFields`

#### SessionAdapterType

- [**Removed**] `func resumedTaskWithURLRequest(_:handler:)`
- [**Added**] `func createTaskWithURLRequest(_:handler:)`

#### SessionTaskType

- [**Added**] `func resume()`

#### SessionTaskError

- [**Removed**] `case ConnectionError(NSError)` 
- [**Added**] `case ConnectionError(ErrorType)` 

### RequestError

- [**Added**] `case InvalidURLComponents(NSURLComponents)`

## Note

Now, we can add `.File` case to `RequestBodyEntity` because we don't have to express requests in NSURLRequest.