### PR TITLE
Fix subclassing NSURLSessionAdapter

### DIFF
--- a/APIKit.xcodeproj/project.pbxproj
+++ b/APIKit.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		7F18BD111C972C69003A31DF /* JSONBodyParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F18BD101C972C69003A31DF /* JSONBodyParameters.swift */; };
 		7F18BD131C972E5A003A31DF /* FormURLEncodedBodyParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F18BD121C972E5A003A31DF /* FormURLEncodedBodyParameters.swift */; };
 		7F18BD1A1C9730ED003A31DF /* URLEncodedSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F18BD181C9730ED003A31DF /* URLEncodedSerialization.swift */; };
+		7F2001D71CF49F3000C5D0EE /* NSURLSessionAdapterSubclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F2001D61CF49F3000C5D0EE /* NSURLSessionAdapterSubclassTests.swift */; };
 		7F2A15BD1CEB5F67009A12A2 /* NSData+NSInputStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F2A15BC1CEB5F67009A12A2 /* NSData+NSInputStream.swift */; };
 		7F7E8F151C8AD4B1008A13A9 /* APIKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F7E8F0B1C8AD4B1008A13A9 /* APIKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7F7E8F161C8AD4B1008A13A9 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7E8F0C1C8AD4B1008A13A9 /* HTTPMethod.swift */; };
@@ -90,6 +91,7 @@
 		7F18BD101C972C69003A31DF /* JSONBodyParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONBodyParameters.swift; sourceTree = "<group>"; };
 		7F18BD121C972E5A003A31DF /* FormURLEncodedBodyParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormURLEncodedBodyParameters.swift; sourceTree = "<group>"; };
 		7F18BD181C9730ED003A31DF /* URLEncodedSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLEncodedSerialization.swift; sourceTree = "<group>"; };
+		7F2001D61CF49F3000C5D0EE /* NSURLSessionAdapterSubclassTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLSessionAdapterSubclassTests.swift; sourceTree = "<group>"; };
 		7F2A15BC1CEB5F67009A12A2 /* NSData+NSInputStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSData+NSInputStream.swift"; sourceTree = "<group>"; };
 		7F7E8F0B1C8AD4B1008A13A9 /* APIKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIKit.h; sourceTree = "<group>"; };
 		7F7E8F0C1C8AD4B1008A13A9 /* HTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
@@ -281,6 +283,7 @@
 			isa = PBXGroup;
 			children = (
 				7F85FB911C9D336D00CEE132 /* NSURLSessionAdapterTests.swift */,
+				7F2001D61CF49F3000C5D0EE /* NSURLSessionAdapterSubclassTests.swift */,
 			);
 			path = SessionAdapterType;
 			sourceTree = "<group>";
@@ -467,6 +470,7 @@
 				7F85FB921C9D336D00CEE132 /* NSURLSessionAdapterTests.swift in Sources */,
 				7F09BF931C8AE8DB00F4A59A /* RequestTypeTests.swift in Sources */,
 				7FA19A3B1C98642F005D25AE /* JSONBodyParametersTests.swift in Sources */,
+				7F2001D71CF49F3000C5D0EE /* NSURLSessionAdapterSubclassTests.swift in Sources */,
 				7F85FB9A1C9D3DA700CEE132 /* TestRequest.swift in Sources */,
 				7F85FB9B1C9D3DA700CEE132 /* TestSessionAdapter.swift in Sources */,
 			);

--- a/Sources/SessionAdapterType/NSURLSessionAdapter.swift
+++ b/Sources/SessionAdapterType/NSURLSessionAdapter.swift
@@ -26,7 +26,7 @@ public class NSURLSessionAdapter: NSObject, SessionAdapterType, NSURLSessionDele
 
     /// Creates `NSURLSessionDataTask` instance using `dataTaskWithRequest(_:completionHandler:)`.
     public func createTaskWithURLRequest(URLRequest: NSURLRequest, handler: (NSData?, NSURLResponse?, ErrorType?) -> Void) -> SessionTaskType {
-        let task = URLSession.dataTaskWithRequest(URLRequest, completionHandler: handler)
+        let task = URLSession.dataTaskWithRequest(URLRequest)
 
         setBuffer(NSMutableData(), forTask: task)
         setHandler(handler, forTask: task)

--- a/Sources/SessionAdapterType/NSURLSessionAdapter.swift
+++ b/Sources/SessionAdapterType/NSURLSessionAdapter.swift
@@ -14,7 +14,7 @@ private var taskAssociatedObjectCompletionHandlerKey = 0
 /// delegate methods that you want to implement. Since `NSURLSessionAdapter` also implements delegate methods
 /// `URLSession(_:task: didCompleteWithError:)` and `URLSession(_:dataTask:didReceiveData:)`, you have to call
 /// `super` in these methods if you implement them.
-public class NSURLSessionAdapter: NSObject, SessionAdapterType, NSURLSessionDelegate {
+public class NSURLSessionAdapter: NSObject, SessionAdapterType, NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate {
     /// The undelying `NSURLSession` instance.
     public var URLSession: NSURLSession!
 

--- a/Tests/APIKit/SessionAdapterType/NSURLSessionAdapterSubclassTests.swift
+++ b/Tests/APIKit/SessionAdapterType/NSURLSessionAdapterSubclassTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import XCTest
+import OHHTTPStubs
+import APIKit
+
+class NSURLSessionAdapterSubclassTests: XCTestCase {
+    class SessionAdapter: NSURLSessionAdapter {
+        var functionCallFlags = [String: Bool]()
+
+        override func URLSession(session: NSURLSession, task: NSURLSessionTask, didCompleteWithError connectionError: NSError?) {
+            functionCallFlags[(#function)] = true
+            super.URLSession(session, task: task, didCompleteWithError: connectionError)
+        }
+
+        override func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveData data: NSData) {
+            functionCallFlags[(#function)] = true
+            super.URLSession(session, dataTask: dataTask, didReceiveData: data)
+        }
+    }
+
+    var adapter: SessionAdapter!
+    var session: Session!
+
+    override func setUp() {
+        super.setUp()
+
+        let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
+        adapter = SessionAdapter(configuration: configuration)
+        session = Session(adapter: adapter)
+    }
+
+    override func tearDown() {
+        OHHTTPStubs.removeAllStubs()
+        super.tearDown()
+    }
+
+    func testDelegateMethodCall() {
+        let data = try! NSJSONSerialization.dataWithJSONObject([:], options: [])
+        
+        OHHTTPStubs.stubRequestsPassingTest({ request in
+            return true
+        }, withStubResponse: { request in
+            return OHHTTPStubsResponse(data: data, statusCode: 200, headers: nil)
+        })
+        
+        let expectation = expectationWithDescription("wait for response")
+        let request = TestRequest()
+        
+        session.sendRequest(request) { result in
+            if case .Failure = result {
+                XCTFail()
+            }
+
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(10.0, handler: nil)
+
+        XCTAssertEqual(adapter.functionCallFlags["URLSession(_:task:didCompleteWithError:)"], true)
+        XCTAssertEqual(adapter.functionCallFlags["URLSession(_:dataTask:didReceiveData:)"], true)
+    }
+}

--- a/Tests/APIKit/SessionAdapterType/NSURLSessionAdapterTests.swift
+++ b/Tests/APIKit/SessionAdapterType/NSURLSessionAdapterTests.swift
@@ -3,15 +3,6 @@ import APIKit
 import XCTest
 import OHHTTPStubs
 
-protocol MockSessionRequestType: RequestType {
-}
-
-extension MockSessionRequestType {
-    var baseURL: NSURL {
-        return NSURL(string: "https://api.github.com")!
-    }
-}
-
 class NSURLSessionAdapterTests: XCTestCase {
     var session: Session!
 


### PR DESCRIPTION
Currently, subclassing NSURLSessionAdapter is not working because its delegate methods are not used.