### PR TITLE
Rename SessionTaskType to SessionTask

### DIFF
--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -37,7 +37,7 @@ open class Session {
     /// - parameter handler: The closure that receives result of the request.
     /// - returns: The new session task.
     @discardableResult
-    open class func send<Req: Request>(_ request: Req, callbackQueue: CallbackQueue? = nil, handler: @escaping (Result<Req.Response, SessionTaskError>) -> Void = { _ in }) -> SessionTaskType? {
+    open class func send<Req: Request>(_ request: Req, callbackQueue: CallbackQueue? = nil, handler: @escaping (Result<Req.Response, SessionTaskError>) -> Void = { _ in }) -> SessionTask? {
         return sharedSession.send(request, callbackQueue: callbackQueue, handler: handler)
     }
 
@@ -55,7 +55,7 @@ open class Session {
     /// - parameter handler: The closure that receives result of the request.
     /// - returns: The new session task.
     @discardableResult
-    open func send<Req: Request>(_ request: Req, callbackQueue: CallbackQueue? = nil, handler: @escaping (Result<Req.Response, SessionTaskError>) -> Void = { _ in }) -> SessionTaskType? {
+    open func send<Req: Request>(_ request: Req, callbackQueue: CallbackQueue? = nil, handler: @escaping (Result<Req.Response, SessionTaskError>) -> Void = { _ in }) -> SessionTask? {
         let callbackQueue = callbackQueue ?? self.callbackQueue
 
         let urlRequest: URLRequest
@@ -114,11 +114,11 @@ open class Session {
         }
     }
 
-    private func setRequest<Req: Request>(_ request: Req, forTask task: SessionTaskType) {
+    private func setRequest<Req: Request>(_ request: Req, forTask task: SessionTask) {
         objc_setAssociatedObject(task, &taskRequestKey, request, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
 
-    private func requestForTask<Req: Request>(_ task: SessionTaskType) -> Req? {
+    private func requestForTask<Req: Request>(_ task: SessionTask) -> Req? {
         return objc_getAssociatedObject(task, &taskRequestKey) as? Req
     }
 }

--- a/Sources/SessionAdapter/SessionAdapter.swift
+++ b/Sources/SessionAdapter/SessionAdapter.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// `SessionTaskType` protocol represents a task for a request.
-public protocol SessionTaskType: class {
+/// `SessionTask` protocol represents a task for a request.
+public protocol SessionTask: class {
     func resume()
     func cancel()
 }
@@ -10,9 +10,9 @@ public protocol SessionTaskType: class {
 /// APIKit provides `URLSessionAdapter`, which conforms to `SessionAdapter`, to connect `URLSession`
 /// with `Session`.
 public protocol SessionAdapter {
-    /// Returns instance that conforms to `SessionTaskType`. `handler` must be called after success or failure.
-    func createTask(with URLRequest: URLRequest, handler: @escaping (Data?, URLResponse?, Error?) -> Void) -> SessionTaskType
+    /// Returns instance that conforms to `SessionTask`. `handler` must be called after success or failure.
+    func createTask(with URLRequest: URLRequest, handler: @escaping (Data?, URLResponse?, Error?) -> Void) -> SessionTask
 
     /// Collects tasks from backend networking stack. `handler` must be called after collecting.
-    func getTasks(with handler: @escaping ([SessionTaskType]) -> Void)
+    func getTasks(with handler: @escaping ([SessionTask]) -> Void)
 }

--- a/Sources/SessionAdapter/URLSessionAdapter.swift
+++ b/Sources/SessionAdapter/URLSessionAdapter.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension URLSessionTask: SessionTaskType {
+extension URLSessionTask: SessionTask {
 
 }
 
@@ -25,7 +25,7 @@ open class URLSessionAdapter: NSObject, SessionAdapter, URLSessionDelegate, URLS
     }
 
     /// Creates `URLSessionDataTask` instance using `dataTaskWithRequest(_:completionHandler:)`.
-    open func createTask(with URLRequest: URLRequest, handler: @escaping (Data?, URLResponse?, Error?) -> Void) -> SessionTaskType {
+    open func createTask(with URLRequest: URLRequest, handler: @escaping (Data?, URLResponse?, Error?) -> Void) -> SessionTask {
         let task = urlSession.dataTask(with: URLRequest)
 
         setBuffer(NSMutableData(), forTask: task)
@@ -37,7 +37,7 @@ open class URLSessionAdapter: NSObject, SessionAdapter, URLSessionDelegate, URLS
     }
 
     /// Aggregates `URLSessionTask` instances in `URLSession` using `getTasksWithCompletionHandler(_:)`.
-    open func getTasks(with handler: @escaping ([SessionTaskType]) -> Void) {
+    open func getTasks(with handler: @escaping ([SessionTask]) -> Void) {
         urlSession.getTasksWithCompletionHandler { dataTasks, uploadTasks, downloadTasks in
             let allTasks = dataTasks as [URLSessionTask]
                 + uploadTasks as [URLSessionTask]

--- a/Tests/APIKit/SessionTests.swift
+++ b/Tests/APIKit/SessionTests.swift
@@ -239,7 +239,7 @@ class SessionTests: XCTestCase {
                 return testSesssion
             }
 
-            private override func send<Req : Request>(_ request: Req, callbackQueue: CallbackQueue?, handler: @escaping (Result<Req.Response, SessionTaskError>) -> Void) -> SessionTaskType? {
+            private override func send<Req : Request>(_ request: Req, callbackQueue: CallbackQueue?, handler: @escaping (Result<Req.Response, SessionTaskError>) -> Void) -> SessionTask? {
                 functionCallFlags[(#function)] = true
                 return super.send(request)
             }

--- a/Tests/APIKit/TestComponents/TestSessionAdapter.swift
+++ b/Tests/APIKit/TestComponents/TestSessionAdapter.swift
@@ -49,14 +49,14 @@ class TestSessionAdapter: SessionAdapter {
         tasks = []
     }
 
-    func createTask(with URLRequest: URLRequest, handler: @escaping (Data?, URLResponse?, Swift.Error?) -> Void) -> SessionTaskType {
+    func createTask(with URLRequest: URLRequest, handler: @escaping (Data?, URLResponse?, Swift.Error?) -> Void) -> SessionTask {
         let task = TestSessionTask(handler: handler)
         tasks.append(task)
 
         return task
     }
 
-    func getTasks(with handler: @escaping ([SessionTaskType]) -> Void) {
+    func getTasks(with handler: @escaping ([SessionTask]) -> Void) {
         handler(tasks.map { $0 })
     }
 }

--- a/Tests/APIKit/TestComponents/TestSessionTask.swift
+++ b/Tests/APIKit/TestComponents/TestSessionTask.swift
@@ -1,7 +1,7 @@
 import Foundation
 import APIKit
 
-class TestSessionTask: SessionTaskType {
+class TestSessionTask: SessionTask {
     
     var handler: (Data?, URLResponse?, Error?) -> Void
     var cancelled = false


### PR DESCRIPTION
For consistency with the other protocols such as Request, SessionAdapter and BodyParameters.