### PR TITLE
Refine Session APIs for Swift 3

### DIFF
--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -20,15 +20,15 @@ open class Session {
     }
 
     // Shared session for class methods
-    private static let privateSharedSession: Session = {
+    private static let privateShared: Session = {
         let configuration = URLSessionConfiguration.default
         let adapter = URLSessionAdapter(configuration: configuration)
         return Session(adapter: adapter)
     }()
 
     /// The shared `Session` instance for class methods, `Session.send(_:handler:)` and `Session.cancelRequests(withType:passingTest:)`.
-    open class var sharedSession: Session {
-        return privateSharedSession
+    open class var shared: Session {
+        return privateShared
     }
 
     /// Calls `send(_:handler:)` of `sharedSession`.
@@ -38,12 +38,12 @@ open class Session {
     /// - returns: The new session task.
     @discardableResult
     open class func send<Req: Request>(_ request: Req, callbackQueue: CallbackQueue? = nil, handler: @escaping (Result<Req.Response, SessionTaskError>) -> Void = { _ in }) -> SessionTask? {
-        return sharedSession.send(request, callbackQueue: callbackQueue, handler: handler)
+        return shared.send(request, callbackQueue: callbackQueue, handler: handler)
     }
 
     /// Calls `cancelRequests(withType:passingTest:)` of `sharedSession`.
     open class func cancelRequests<Req: Request>(withType requestType: Req.Type, passingTest test: @escaping (Req) -> Bool = { _ in true }) {
-        sharedSession.cancelRequests(withType: requestType, passingTest: test)
+        shared.cancelRequests(withType: requestType, passingTest: test)
     }
 
     /// Sends a request and receives the result as the argument of `handler` closure. This method takes

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -26,7 +26,7 @@ open class Session {
         return Session(adapter: adapter)
     }()
 
-    /// The shared `Session` instance for class methods, `Session.send(_:handler:)` and `Session.cancelRequests(withType:passingTest:)`.
+    /// The shared `Session` instance for class methods, `Session.send(_:handler:)` and `Session.cancelRequests(with:passingTest:)`.
     open class var shared: Session {
         return privateShared
     }
@@ -41,9 +41,9 @@ open class Session {
         return shared.send(request, callbackQueue: callbackQueue, handler: handler)
     }
 
-    /// Calls `cancelRequests(withType:passingTest:)` of `sharedSession`.
-    open class func cancelRequests<Req: Request>(withType requestType: Req.Type, passingTest test: @escaping (Req) -> Bool = { _ in true }) {
-        shared.cancelRequests(withType: requestType, passingTest: test)
+    /// Calls `cancelRequests(with:passingTest:)` of `sharedSession`.
+    open class func cancelRequests<Req: Request>(with requestType: Req.Type, passingTest test: @escaping (Req) -> Bool = { _ in true }) {
+        shared.cancelRequests(with: requestType, passingTest: test)
     }
 
     /// Sends a request and receives the result as the argument of `handler` closure. This method takes
@@ -100,7 +100,7 @@ open class Session {
     /// Cancels requests that passes the test.
     /// - parameter requestType: The request type to cancel.
     /// - parameter test: The test closure that determines if a request should be cancelled or not.
-    open func cancelRequests<Req: Request>(withType requestType: Req.Type, passingTest test: @escaping (Req) -> Bool = { _ in true }) {
+    open func cancelRequests<Req: Request>(with requestType: Req.Type, passingTest test: @escaping (Req) -> Bool = { _ in true }) {
         adapter.getTasks { [weak self] tasks in
             return tasks
                 .filter { task in

--- a/Tests/APIKit/SessionAdapterType/URLSessionAdapterTests.swift
+++ b/Tests/APIKit/SessionAdapterType/URLSessionAdapterTests.swift
@@ -106,7 +106,7 @@ class URLSessionAdapterTests: XCTestCase {
         }
 
         DispatchQueue.main.async {
-            self.session.cancelRequests(withType: TestRequest.self)
+            self.session.cancelRequests(with: TestRequest.self)
         }
 
         waitForExpectations(timeout: 10.0, handler: nil)

--- a/Tests/APIKit/SessionTests.swift
+++ b/Tests/APIKit/SessionTests.swift
@@ -226,7 +226,7 @@ class SessionTests: XCTestCase {
 
     // MARK: Class methods
     func testSharedSession() {
-        XCTAssert(Session.sharedSession === Session.sharedSession)
+        XCTAssert(Session.shared === Session.shared)
     }
 
     func testSubclassClassMethods() {
@@ -235,7 +235,7 @@ class SessionTests: XCTestCase {
 
             var functionCallFlags = [String: Bool]()
 
-            override class var sharedSession: Session {
+            override class var shared: Session {
                 return testSesssion
             }
 

--- a/Tests/APIKit/SessionTests.swift
+++ b/Tests/APIKit/SessionTests.swift
@@ -141,7 +141,7 @@ class SessionTests: XCTestCase {
             expectation.fulfill()
         }
         
-        session.cancelRequests(withType: TestRequest.self)
+        session.cancelRequests(with: TestRequest.self)
         
         waitForExpectations(timeout: 1.0, handler: nil)
     }
@@ -169,7 +169,7 @@ class SessionTests: XCTestCase {
             failureExpectation.fulfill()
         }
         
-        session.cancelRequests(withType: TestRequest.self) { request in
+        session.cancelRequests(with: TestRequest.self) { request in
             return request.path == failureRequest.path
         }
         
@@ -219,7 +219,7 @@ class SessionTests: XCTestCase {
             failureExpectation.fulfill()
         }
         
-        session.cancelRequests(withType: TestRequest.self)
+        session.cancelRequests(with: TestRequest.self)
 
         waitForExpectations(timeout: 1.0, handler: nil)
     }
@@ -244,16 +244,16 @@ class SessionTests: XCTestCase {
                 return super.send(request)
             }
 
-            private override func cancelRequests<Req : Request>(withType requestType: Req.Type, passingTest test: @escaping (Req) -> Bool) {
+            private override func cancelRequests<Req : Request>(with requestType: Req.Type, passingTest test: @escaping (Req) -> Bool) {
                 functionCallFlags[(#function)] = true
             }
         }
 
         let testSession = SessionSubclass.testSesssion
         SessionSubclass.send(TestRequest())
-        SessionSubclass.cancelRequests(withType: TestRequest.self)
+        SessionSubclass.cancelRequests(with: TestRequest.self)
 
         XCTAssertEqual(testSession.functionCallFlags["send(_:callbackQueue:handler:)"], true)
-        XCTAssertEqual(testSession.functionCallFlags["cancelRequests(withType:passingTest:)"], true)
+        XCTAssertEqual(testSession.functionCallFlags["cancelRequests(with:passingTest:)"], true)
     }
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,8 @@
 coverage:
     ignore: Tests
+    status:
+      patch: false
+      changes: false
 
 comment: false
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,5 @@
 coverage:
     ignore: Tests
-    status:
-      patch: false
-      changes: false
 
 comment: false
 


### PR DESCRIPTION
- Rename `Session.sharedSession` to `Session.shared`.
- Rename `cancelRequests(withType:passingTest:)` to `cancelRequests(with:passingTest:)`.

In #194, I said that the first label of cancel method needs the word "Type", but it apparently expresses  type of requests even if the argument label does not have "Type" 🙇 