### PR TITLE
Support protocol buffers

### DIFF
--- a/APIKit.xcodeproj/project.pbxproj
+++ b/APIKit.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		7F7048F11D9D8A12003C99F6 /* SessionTaskError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7048EE1D9D8A12003C99F6 /* SessionTaskError.swift */; };
 		7F7048F31D9D8A1F003C99F6 /* URLEncodedSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7048F21D9D8A1F003C99F6 /* URLEncodedSerialization.swift */; };
 		7FA1690D1D9D8C80006C982B /* HTTPStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FA1690C1D9D8C80006C982B /* HTTPStub.swift */; };
+		ECA831481DE4DDBF004EB1B5 /* ProtobufDataParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA831471DE4DDBF004EB1B5 /* ProtobufDataParser.swift */; };
+		ECA8314A1DE4DEBE004EB1B5 /* ProtobufDataParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA831491DE4DEBE004EB1B5 /* ProtobufDataParserTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -126,6 +128,8 @@
 		7F8ECDFD1B6A799E00234E04 /* Demo.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Demo.playground; sourceTree = "<group>"; };
 		7FA1690C1D9D8C80006C982B /* HTTPStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPStub.swift; sourceTree = "<group>"; };
 		CD5115241B1FFBA900514240 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECA831471DE4DDBF004EB1B5 /* ProtobufDataParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProtobufDataParser.swift; path = Sources/APIKit/DataParser/ProtobufDataParser.swift; sourceTree = SOURCE_ROOT; };
+		ECA831491DE4DEBE004EB1B5 /* ProtobufDataParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtobufDataParserTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -240,6 +244,7 @@
 			children = (
 				7F698E411D9D680C00F1561D /* FormURLEncodedDataParserTests.swift */,
 				7F698E421D9D680C00F1561D /* JSONDataParserTests.swift */,
+				ECA831491DE4DEBE004EB1B5 /* ProtobufDataParserTests.swift */,
 				7F698E431D9D680C00F1561D /* StringDataParserTests.swift */,
 			);
 			path = DataParserType;
@@ -327,6 +332,7 @@
 				7F7048E41D9D8A08003C99F6 /* DataParser.swift */,
 				7F7048E51D9D8A08003C99F6 /* FormURLEncodedDataParser.swift */,
 				7F7048E61D9D8A08003C99F6 /* JSONDataParser.swift */,
+				ECA831471DE4DDBF004EB1B5 /* ProtobufDataParser.swift */,
 				7F7048E71D9D8A08003C99F6 /* StringDataParser.swift */,
 			);
 			path = DataParser;
@@ -460,6 +466,7 @@
 				7F7048E91D9D8A08003C99F6 /* FormURLEncodedDataParser.swift in Sources */,
 				7F7048E11D9D89FB003C99F6 /* FormURLEncodedBodyParameters.swift in Sources */,
 				7F7048F11D9D8A12003C99F6 /* SessionTaskError.swift in Sources */,
+				ECA831481DE4DDBF004EB1B5 /* ProtobufDataParser.swift in Sources */,
 				7F7048F31D9D8A1F003C99F6 /* URLEncodedSerialization.swift in Sources */,
 				7F7048D71D9D89F2003C99F6 /* URLSessionAdapter.swift in Sources */,
 				7F7048EB1D9D8A08003C99F6 /* StringDataParser.swift in Sources */,
@@ -476,6 +483,7 @@
 				7F698E5B1D9D680C00F1561D /* SessionCallbackQueueTests.swift in Sources */,
 				7F698E501D9D680C00F1561D /* FormURLEncodedBodyParametersTests.swift in Sources */,
 				7F698E581D9D680C00F1561D /* RequestTests.swift in Sources */,
+				ECA8314A1DE4DEBE004EB1B5 /* ProtobufDataParserTests.swift in Sources */,
 				7F698E5E1D9D680C00F1561D /* TestRequest.swift in Sources */,
 				7F698E601D9D680C00F1561D /* TestSessionTask.swift in Sources */,
 				7FA1690D1D9D8C80006C982B /* HTTPStub.swift in Sources */,

--- a/APIKit.xcodeproj/project.pbxproj
+++ b/APIKit.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		7FA1690D1D9D8C80006C982B /* HTTPStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FA1690C1D9D8C80006C982B /* HTTPStub.swift */; };
 		ECA831481DE4DDBF004EB1B5 /* ProtobufDataParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA831471DE4DDBF004EB1B5 /* ProtobufDataParser.swift */; };
 		ECA8314A1DE4DEBE004EB1B5 /* ProtobufDataParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA831491DE4DEBE004EB1B5 /* ProtobufDataParserTests.swift */; };
+		ECA8314C1DE4E677004EB1B5 /* ProtobufBodyParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA8314B1DE4E677004EB1B5 /* ProtobufBodyParameters.swift */; };
+		ECA8314E1DE4E739004EB1B5 /* ProtobufBodyParametersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA8314D1DE4E739004EB1B5 /* ProtobufBodyParametersTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -130,6 +132,8 @@
 		CD5115241B1FFBA900514240 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ECA831471DE4DDBF004EB1B5 /* ProtobufDataParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProtobufDataParser.swift; path = Sources/APIKit/DataParser/ProtobufDataParser.swift; sourceTree = SOURCE_ROOT; };
 		ECA831491DE4DEBE004EB1B5 /* ProtobufDataParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtobufDataParserTests.swift; sourceTree = "<group>"; };
+		ECA8314B1DE4E677004EB1B5 /* ProtobufBodyParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProtobufBodyParameters.swift; path = Sources/APIKit/BodyParameters/ProtobufBodyParameters.swift; sourceTree = SOURCE_ROOT; };
+		ECA8314D1DE4E739004EB1B5 /* ProtobufBodyParametersTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtobufBodyParametersTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -180,6 +184,7 @@
 				7F7048DB1D9D89FB003C99F6 /* FormURLEncodedBodyParameters.swift */,
 				7F7048DC1D9D89FB003C99F6 /* JSONBodyParameters.swift */,
 				7F7048DD1D9D89FB003C99F6 /* MultipartFormDataBodyParameters.swift */,
+				ECA8314B1DE4E677004EB1B5 /* ProtobufBodyParameters.swift */,
 				7F7048D81D9D89FB003C99F6 /* AbstractInputStream.m */,
 			);
 			path = BodyParameters;
@@ -234,6 +239,7 @@
 				7F698E3C1D9D680C00F1561D /* FormURLEncodedBodyParametersTests.swift */,
 				7F698E3D1D9D680C00F1561D /* JSONBodyParametersTests.swift */,
 				7F698E3E1D9D680C00F1561D /* MultipartFormDataParametersTests.swift */,
+				ECA8314D1DE4E739004EB1B5 /* ProtobufBodyParametersTests.swift */,
 				7F698E3F1D9D680C00F1561D /* URLEncodedSerializationTests.swift */,
 			);
 			path = BodyParametersType;
@@ -464,6 +470,7 @@
 				7F7048D61D9D89F2003C99F6 /* SessionAdapter.swift in Sources */,
 				7F7048EF1D9D8A12003C99F6 /* RequestError.swift in Sources */,
 				7F7048E91D9D8A08003C99F6 /* FormURLEncodedDataParser.swift in Sources */,
+				ECA8314C1DE4E677004EB1B5 /* ProtobufBodyParameters.swift in Sources */,
 				7F7048E11D9D89FB003C99F6 /* FormURLEncodedBodyParameters.swift in Sources */,
 				7F7048F11D9D8A12003C99F6 /* SessionTaskError.swift in Sources */,
 				ECA831481DE4DDBF004EB1B5 /* ProtobufDataParser.swift in Sources */,
@@ -492,6 +499,7 @@
 				7F698E541D9D680C00F1561D /* FormURLEncodedDataParserTests.swift in Sources */,
 				7F698E591D9D680C00F1561D /* URLSessionAdapterSubclassTests.swift in Sources */,
 				7F698E551D9D680C00F1561D /* JSONDataParserTests.swift in Sources */,
+				ECA8314E1DE4E739004EB1B5 /* ProtobufBodyParametersTests.swift in Sources */,
 				7F698E511D9D680C00F1561D /* JSONBodyParametersTests.swift in Sources */,
 				7F698E521D9D680C00F1561D /* MultipartFormDataParametersTests.swift in Sources */,
 				7F698E531D9D680C00F1561D /* URLEncodedSerializationTests.swift in Sources */,

--- a/Sources/APIKit/BodyParameters/ProtobufBodyParameters.swift
+++ b/Sources/APIKit/BodyParameters/ProtobufBodyParameters.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// `ProtobufBodyParameters` serializes Protobuf object for HTTP body and states its content type is Protobuf.
+public struct ProtobufBodyParameters: BodyParameters {
+    /// The Protobuf object to be serialized.
+    public let protobufObject: Data
+    
+    /// Returns `ProtobufBodyParameters`.
+    public init(protobufObject: Data) {
+        self.protobufObject = protobufObject
+    }
+
+    // MARK: - BodyParameters
+
+    /// `Content-Type` to send. The value for this property will be set to `Accept` HTTP header field.
+    public var contentType: String {
+        return "application/protobuf"
+    }
+
+    /// Builds `RequestBodyEntity.data` that represents `ProtobufObject`.
+    public func buildEntity() throws -> RequestBodyEntity {
+        return .data(protobufObject)
+    }
+}

--- a/Sources/APIKit/DataParser/ProtobufDataParser.swift
+++ b/Sources/APIKit/DataParser/ProtobufDataParser.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// `ProtobufDataParser` response Data data.
+public class ProtobufDataParser: DataParser {
+    /// Returns `ProtobufDataParser`.
+    public init() {}
+    
+    // MARK: - DataParser
+    
+    /// Value for `Accept` header field of HTTP request.
+    public var contentType: String? {
+        return "application/protobuf"
+    }
+    
+    /// Return `Any` that expresses structure of Data response.
+    public func parse(data: Data) throws -> Any {
+        return data
+    }
+}

--- a/Tests/APIKitTests/BodyParametersType/ProtobufBodyParametersTests.swift
+++ b/Tests/APIKitTests/BodyParametersType/ProtobufBodyParametersTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import XCTest
+import APIKit
+
+class ProtobufBodyParametersTests: XCTestCase {
+    func testProtobufSuccess() {
+        let object = NSKeyedArchiver.archivedData(withRootObject: ["foo": 1, "bar": 2, "baz": 3])
+        let parameters = ProtobufBodyParameters(protobufObject: object)
+        XCTAssertEqual(parameters.contentType, "application/protobuf")
+
+        do {
+            guard case .data(let data) = try parameters.buildEntity() else {
+                XCTFail()
+                return
+            }
+
+            let dictionary = NSKeyedUnarchiver.unarchiveObject(with: data) as? [String: Int]
+            XCTAssertEqual(dictionary?["foo"], 1)
+            XCTAssertEqual(dictionary?["bar"], 2)
+            XCTAssertEqual(dictionary?["baz"], 3)
+        } catch {
+            XCTFail()
+        }
+    }
+}

--- a/Tests/APIKitTests/DataParserType/ProtobufDataParserTests.swift
+++ b/Tests/APIKitTests/DataParserType/ProtobufDataParserTests.swift
@@ -8,21 +8,16 @@ class ProtobufDataParserTests: XCTestCase {
         XCTAssertEqual(parser.contentType, "application/protobuf")
     }
     
-    func testJSONSuccess() {
-        let dictionary = [
-            "foo": 1,
-            "bar": 2,
-            "baz": 3
-        ]
-        let data = NSKeyedArchiver.archivedData(withRootObject: dictionary)
+    func testProtobufSuccess() {
+        let data = NSKeyedArchiver.archivedData(withRootObject: ["foo": 1, "bar": 2, "baz": 3])
         let parser = ProtobufDataParser()
         
         do {
             let object = try parser.parse(data: data) as! Data
-            let parsedDictionary = NSKeyedUnarchiver.unarchiveObject(with: object) as! [String: Int]
-            XCTAssertEqual(parsedDictionary["foo"], dictionary["foo"])
-            XCTAssertEqual(parsedDictionary["bar"], dictionary["bar"])
-            XCTAssertEqual(parsedDictionary["baz"], dictionary["baz"])
+            let dictionary = NSKeyedUnarchiver.unarchiveObject(with: object) as? [String: Int]
+            XCTAssertEqual(dictionary?["foo"], 1)
+            XCTAssertEqual(dictionary?["bar"], 2)
+            XCTAssertEqual(dictionary?["baz"], 3)
         } catch {
             XCTFail()
         }

--- a/Tests/APIKitTests/DataParserType/ProtobufDataParserTests.swift
+++ b/Tests/APIKitTests/DataParserType/ProtobufDataParserTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import APIKit
+import XCTest
+
+class ProtobufDataParserTests: XCTestCase {
+    func testContentType() {
+        let parser = ProtobufDataParser()
+        XCTAssertEqual(parser.contentType, "application/protobuf")
+    }
+    
+    func testJSONSuccess() {
+        let dictionary = [
+            "foo": 1,
+            "bar": 2,
+            "baz": 3
+        ]
+        let data = NSKeyedArchiver.archivedData(withRootObject: dictionary)
+        let parser = ProtobufDataParser()
+        
+        do {
+            let object = try parser.parse(data: data) as! Data
+            let parsedDictionary = NSKeyedUnarchiver.unarchiveObject(with: object) as! [String: Int]
+            XCTAssertEqual(parsedDictionary["foo"], dictionary["foo"])
+            XCTAssertEqual(parsedDictionary["bar"], dictionary["bar"])
+            XCTAssertEqual(parsedDictionary["baz"], dictionary["baz"])
+        } catch {
+            XCTFail()
+        }
+    }
+}


### PR DESCRIPTION
## Proposal

It would be great to have Protocol Buffers support in APIKit. I added `ProtobufDataParser` and `ProtobufBodyParameters` for its use case since JSON content type is default.

## What's Protocol Buffers?

See detailed info [here](https://developers.google.com/protocol-buffers/).

## How to use

```
protocol ProtobufRequest: Request {}

extension ProtobufRequest {
    var baseURL: URL {
        return URL(string: "http://localhost:8080")!
    }
    
    var dataParser: DataParser {
        return ProtobufDataParser()
    }
}

extension ProtobufRequest where Response: ProtobufGeneratedMessage {
    func response(from object: Any, urlResponse: HTTPURLResponse) throws -> Response {
        guard let data = object as? Data else {
            throw ResponseError.unexpectedObject(object)
        }
        return try Response(protobuf: data)
    }
}

struct MyModelRequest: ProtobufRequest {
    typealias Response = MyModel
    
    var path: String {
        return ""
    }
    
    var method: HTTPMethod {
        return .get
    }
}

let request = MyModelRequest()
Session.send(request) { result in
    switch result {
    case .success(let data): break
    case .failure(let error): break
    }
}
```

## Plugin I tested with 
[swift protobuf](https://github.com/apple/swift-protobuf) version: 0.9.24

I could provide an introduction of the plugin for test environment if you want.