### PR TITLE
Issue #220 Changes the access control of CallbackQueue.execute()

### DIFF
--- a/Sources/APIKit/CallbackQueue.swift
+++ b/Sources/APIKit/CallbackQueue.swift
@@ -14,7 +14,7 @@ public enum CallbackQueue {
     /// Dispatches callback closure on associated dispatch queue.
     case dispatchQueue(DispatchQueue)
 
-    internal func execute(closure: @escaping () -> Void) {
+    public func execute(closure: @escaping () -> Void) {
         switch self {
         case .main:
             DispatchQueue.main.async {


### PR DESCRIPTION
Changes the access control of CallbackQueue.execute() to `public` from `internal` for using outside of APIKit module.