### PR TITLE
Data parser associated types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ Carthage/Build
 
 fastlane/report.xml
 fastlane/screenshots
+
+.DS_Store

--- a/Sources/APIKit/DataParser/DataParser.swift
+++ b/Sources/APIKit/DataParser/DataParser.swift
@@ -2,10 +2,12 @@ import Foundation
 
 /// `DataParser` protocol provides inteface to parse HTTP response body and to state Content-Type to accept.
 public protocol DataParser {
+    associatedtype Parsed
+
     /// Value for `Accept` header field of HTTP request.
     var contentType: String? { get }
 
     /// Return `Any` that expresses structure of response such as JSON and XML.
     /// - Throws: `Error` when parser encountered invalid format data.
-    func parse(data: Data) throws -> Any
+    func parse(data: Data) throws -> Parsed
 }

--- a/Tests/APIKitTests/SessionTests.swift
+++ b/Tests/APIKitTests/SessionTests.swift
@@ -175,7 +175,7 @@ class SessionTests: XCTestCase {
         waitForExpectations(timeout: 1.0, handler: nil)
     }
 
-    struct AnotherTestRequest: Request {
+    struct AnotherTestRequest: JSONRequest {
         typealias Response = Void
 
         var baseURL: URL {

--- a/Tests/APIKitTests/TestComponents/TestRequest.swift
+++ b/Tests/APIKitTests/TestComponents/TestRequest.swift
@@ -1,7 +1,7 @@
 import Foundation
 import APIKit
 
-struct TestRequest: Request {
+struct TestRequest: JSONRequest {
     var absoluteURL: URL? {
         let urlRequest = try? buildURLRequest()
         return urlRequest?.url


### PR DESCRIPTION
DataParser should not be required to return Any and have objects checked for type safety at runtime. This PR allows us to use the Swift build time type checking system with very minimal changes to existing code. The only API breaking change is that Request classes using the default JSONDataParser should now conform to JSONRequest, instead of just Request. This is because protocol extensions cannot declare default associated types.