### PR TITLE
Fix `progressHandler` to work properly

### DIFF
--- a/Sources/APIKit/SessionAdapter/URLSessionAdapter.swift
+++ b/Sources/APIKit/SessionAdapter/URLSessionAdapter.swift
@@ -68,7 +68,7 @@ open class URLSessionAdapter: NSObject, SessionAdapter, URLSessionDelegate, URLS
     }
 
     private func progressHandler(for task: URLSessionTask) -> ((Int64, Int64, Int64) -> Void)? {
-        return objc_getAssociatedObject(task, &taskAssociatedObjectCompletionHandlerKey) as? (Int64, Int64, Int64) -> Void
+        return objc_getAssociatedObject(task, &taskAssociatedObjectProgressHandlerKey) as? (Int64, Int64, Int64) -> Void
     }
     // MARK: URLSessionTaskDelegate
     open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {

--- a/Tests/APIKitTests/SessionAdapterType/URLSessionAdapterSubclassTests.swift
+++ b/Tests/APIKitTests/SessionAdapterType/URLSessionAdapterSubclassTests.swift
@@ -64,14 +64,9 @@ class URLSessionAdapterSubclassTests: XCTestCase {
         let adapter = SessionAdapter(configuration: configuration)
         let session = Session(adapter: adapter)
 
-        session.send(request,
-            completionHandler: { result in
-                if case .failure = result {
-                    XCTFail()
-                }
-
-                expectation.fulfill()
-            })
+        session.send(request, progressHandler: { _, _, _ in
+            expectation.fulfill()
+        })
 
         waitForExpectations(timeout: 10.0, handler: nil)
         XCTAssertEqual(adapter.functionCallFlags["urlSession(_:task:didSendBodyData:totalBytesSent:totalBytesExpectedToSend:)"], true)


### PR DESCRIPTION
```progressHandler(bytesSent:totalBytesSent:totalBytesExpectedToSend:)``` parameter in ```Session.send``` is not working.

The reason is ```progressHandler``` getter reference the wrong key in ```URLSessionAdapter.swift```

So fix it and write unit test! 