### PR TITLE
Rename Request.Parser to Request.DataParser

### DIFF
--- a/Sources/APIKit/Request.swift
+++ b/Sources/APIKit/Request.swift
@@ -11,7 +11,7 @@ import Result
 public protocol Request {
     /// The response type associated with the request type.
     associatedtype Response
-    associatedtype Parser: DataParser
+    associatedtype DataParser: APIKit.DataParser
 
     /// The base URL.
     var baseURL: URL { get }
@@ -42,7 +42,7 @@ public protocol Request {
     var headerFields: [String: String] { get }
 
     /// The parser object that states `Content-Type` to accept and parses response body.
-    var dataParser: Parser { get }
+    var dataParser: DataParser { get }
 
     /// Intercepts `URLRequest` which is created by `Request.buildURLRequest()`. If an error is
     /// thrown in this method, the result of `Session.send()` turns `.failure(.requestError(error))`.
@@ -54,12 +54,12 @@ public protocol Request {
     /// The default implementation of this method is provided to throw `RequestError.unacceptableStatusCode`
     /// if the HTTP status code is not in `200..<300`.
     /// - Throws: `Error`
-    func intercept(object: Parser.Parsed, urlResponse: HTTPURLResponse) throws -> Parser.Parsed
+    func intercept(object: DataParser.Parsed, urlResponse: HTTPURLResponse) throws -> DataParser.Parsed
 
     /// Build `Response` instance from raw response object. This method is called after
     /// `intercept(object:urlResponse:)` if it does not throw any error.
     /// - Throws: `Error`
-    func response(from object: Parser.Parsed, urlResponse: HTTPURLResponse) throws -> Response
+    func response(from object: DataParser.Parsed, urlResponse: HTTPURLResponse) throws -> Response
 }
 
 public extension Request {
@@ -92,7 +92,7 @@ public extension Request {
         return urlRequest
     }
 
-    public func intercept(object: Parser.Parsed, urlResponse: HTTPURLResponse) throws -> Parser.Parsed {
+    public func intercept(object: DataParser.Parsed, urlResponse: HTTPURLResponse) throws -> DataParser.Parsed {
         guard 200..<300 ~= urlResponse.statusCode else {
             throw ResponseError.unacceptableStatusCode(urlResponse.statusCode)
         }


### PR DESCRIPTION
The name `Parser` is a little bit ambiguous because there're some other things to parse around Request. I have renamed this associated type as `DataParser` to declare that this type parses `Data` explicitly.