### PR TITLE
Fix typo in the podspec file

### DIFF
--- a/APIKit.podspec
+++ b/APIKit.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
       :tag => "#{s.version}",
   }
 
-  s.pod_target_xcconfigs = { "SWIFT_VERSION" => "4.0" }
+  s.pod_target_xcconfig = { "SWIFT_VERSION" => "4.0" }
 
   s.license = {
     :type => "MIT",


### PR DESCRIPTION
Because of typo in the podspec file, I couldn't install using Cocoapods by specifying repository and tag. I fixed this typo.

**Podfile description**

```ruby
pod 'APIKit', :git => 'https://github.com/ishkawa/APIKit.git', :tag => '3.2.0'
```

**Installation Error**

```shell
$ pod install
Analyzing dependencies
Pre-downloading: `APIKit` from `https://github.com/ishkawa/APIKit.git`, tag `3.2.0`
[!] Failed to load 'APIKit' podspec: 
[!] Invalid `APIKit.podspec` file: undefined method `pod_target_xcconfigs=' for #<Pod::Specification name="APIKit">.

 #  from /var/folders/sd/v8vlggpj7k5cq94ckr7b1n680000gn/T/d20180122-1220-28wdgc/APIKit.podspec:26
 #  -------------------------------------------
 #  
 >    s.pod_target_xcconfigs = { "SWIFT_VERSION" => "4.0" }
 #  
 #  -------------------------------------------
```