### PR TITLE
Use buffer.deallocate() instead of buffer.deallocate(capacity:) in Swift 4.1 or later

### DIFF
--- a/Sources/APIKit/BodyParameters/Data+InputStream.swift
+++ b/Sources/APIKit/BodyParameters/Data+InputStream.swift
@@ -29,7 +29,7 @@ extension Data {
             }
         } while readSize > 0
 
-        buffer.deallocate(capacity: bufferSize)
+        buffer.deallocate()
 
         self.init(data)
     }

--- a/Sources/APIKit/BodyParameters/Data+InputStream.swift
+++ b/Sources/APIKit/BodyParameters/Data+InputStream.swift
@@ -29,7 +29,11 @@ extension Data {
             }
         } while readSize > 0
 
+        #if swift(>=4.1)
         buffer.deallocate()
+        #else
+        buffer.deallocate(capacity: bufferSize)
+        #endif
 
         self.init(data)
     }


### PR DESCRIPTION
`UnsafeMutablePointer.deallocate(capacity:)` is deprecated in Swift 4.1.

> 'deallocate(capacity:)' is deprecated: Swift currently only supports freeing entire heap blocks, use deallocate() instead

Since we deallocates entire heap blocks originally, we can just replace `deallocate(capacity:)` with `deallocate()` as compiler suggests.