### PR TITLE
ExpressibleByDictionaryLiteral for JSONBodyParameters

### DIFF
--- a/Sources/APIKit/BodyParameters/JSONBodyParameters.swift
+++ b/Sources/APIKit/BodyParameters/JSONBodyParameters.swift
@@ -32,3 +32,12 @@ public struct JSONBodyParameters: BodyParameters {
         return .data(try JSONSerialization.data(withJSONObject: JSONObject, options: writingOptions))
     }
 }
+
+extension JSONBodyParameters: ExpressibleByDictionaryLiteral {
+    public typealias Key = String
+    public typealias Value = Any
+
+    public init(dictionaryLiteral elements: (Key, Value)...) {
+        self.init(JSONObject: Dictionary(uniqueKeysWithValues: elements))
+    }
+}

--- a/Tests/APIKitTests/BodyParametersType/JSONBodyParametersTests.swift
+++ b/Tests/APIKitTests/BodyParametersType/JSONBodyParametersTests.swift
@@ -36,4 +36,25 @@ class JSONBodyParametersTests: XCTestCase {
             XCTAssertEqual(nserror.code, 3840)
         }
     }
+
+    func testDictionaryLiteral() {
+        let object = ["foo": 1, "bar": 2, "baz": 3]
+
+        let parameters1: JSONBodyParameters = .init(JSONObject: object)
+        let parameters2: JSONBodyParameters = ["foo": 1, "bar": 2, "baz": 3]
+        do {
+            guard case .data(let data1) = try parameters1.buildEntity(),
+                case .data(let data2) = try parameters2.buildEntity() else {
+                XCTFail()
+                return
+            }
+            let dictionary1 = try JSONSerialization.jsonObject(with: data1, options: [])
+            let dictionary2 = try JSONSerialization.jsonObject(with: data2, options: [])
+            XCTAssertEqual((dictionary1 as? [String: Int])?["foo"], (dictionary2 as? [String: Int])?["foo"])
+            XCTAssertEqual((dictionary1 as? [String: Int])?["bar"], (dictionary2 as? [String: Int])?["bar"])
+            XCTAssertEqual((dictionary1 as? [String: Int])?["baz"], (dictionary2 as? [String: Int])?["baz"])
+        } catch {
+            XCTFail()
+        }
+    }
 }


### PR DESCRIPTION
There are redundant codes for initializing `JSONBodyParameters`.
I make it possible to initialize simply from Dictionary Literal.

## Before
```swift
let object = ["foo": 1, "bar": 2, "baz": 3]
let parameters = JSONBodyParameters(JSONObject: object)
```

## After
```swift
let parameters: JSONBodyParameters = ["foo": 1, "bar": 2, "baz": 3]
```
or
```swift
let parameters = ["foo": 1, "bar": 2, "baz": 3] as JSONBodyParameters
```