### PR TITLE
Add `TextPlainParameters` to support sending plain text request body

### DIFF
--- a/Documentation/APIKit2MigrationGuide.md
+++ b/Documentation/APIKit2MigrationGuide.md
@@ -77,6 +77,7 @@ APIKit provides 3 parameters types that conform to `BodyParametersType`:
 - [**Added**] `class JSONBodyParameters`
 - [**Added**] `class FormURLEncodedBodyParameters`
 - [**Added**] `class MultipartFormDataBodyParameters`
+- [**Added**] `class TextPlainParameters`
 
 ### HTTP Headers
 

--- a/Documentation/ConvenienceParametersAndActualParameters.md
+++ b/Documentation/ConvenienceParametersAndActualParameters.md
@@ -94,3 +94,4 @@ APIKit provides 3 body parameters type listed below:
 |`JSONBodyParameters`             |`Any`                                   |
 |`FormURLEncodedBodyParameters`   |`[String: Any]`                         |
 |`MultipartFormDataBodyParameters`|`[MultipartFormDataBodyParameters.Part]`|
+|`TextPlainParameters`            |`String`                                |

--- a/Sources/APIKit/BodyParameters/TextPlainParameters.swift
+++ b/Sources/APIKit/BodyParameters/TextPlainParameters.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// `TextPlainParameters` serializes plain text for HTTP body and states its content type is plain text.
+public struct TextPlainParameters: BodyParameters {
+   /// The plain text to be serialized.
+   private let text: String
+
+   /// Returns `TextPlainParameters` that is initialized with plain text.
+   public init(text: String) {
+       self.text = text
+   }
+
+   // MARK: - BodyParameters
+   /// `Content-Type` to send. The value for this property will be set to `Accept` HTTP header field.
+   public var contentType: String {
+       "text/plain"
+   }
+
+   /// Builds `RequestBodyEntity.data` that represents plain text.
+   public func buildEntity() throws -> RequestBodyEntity {
+       .data(Data(self.text.utf8))
+   }
+}

--- a/Tests/APIKitTests/BodyParametersType/TextPlainParametersTests.swift
+++ b/Tests/APIKitTests/BodyParametersType/TextPlainParametersTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import XCTest
+import APIKit
+
+class TextPlainParametersTests: XCTestCase {
+    func testTextPlainSuccess() throws {
+       let text = "Hello, World!"
+       let parameters = TextPlainParameters(text: text)
+       
+       XCTAssertEqual(parameters.contentType, "text/plain")
+       
+       guard case .data(let data) = try parameters.buildEntity() else {
+           XCTFail()
+           return
+       }
+       
+       let decodedText = String(data: data, encoding: .utf8)
+       XCTAssertEqual(decodedText, text)
+    }
+
+    func testTextPlainEmpty() throws {
+       let text = ""
+       let parameters = TextPlainParameters(text: text)
+       
+       XCTAssertEqual(parameters.contentType, "text/plain")
+       
+       guard case .data(let data) = try parameters.buildEntity() else {
+           XCTFail()
+           return
+       }
+       
+       let decodedText = String(data: data, encoding: .utf8)
+       XCTAssertEqual(decodedText, text)
+    }
+
+    func testTextPlainUnicode() throws {
+        let text = "Hello, World! 😄🌍"
+        let parameters = TextPlainParameters(text: text)
+        
+        XCTAssertEqual(parameters.contentType, "text/plain")
+        
+        guard case .data(let data) = try parameters.buildEntity() else {
+            XCTFail()
+            return
+        }
+        
+        let decodedText = String(data: data, encoding: .utf8)
+        XCTAssertEqual(decodedText, text)
+    }
+}


### PR DESCRIPTION
While working with Apple's AdServices framework, I encountered a scenario where I needed to make a POST request to [`https://api-adservices.apple.com/api/v1/`](https://developer.apple.com/documentation/adservices/aaattribution/attributiontoken()). During this process, I noticed that the server expected the request body to have a content type of text/plain.

To better support this use case and enhance APIKit's compatibility with the AdServices API, I introduced TextPlainParameters. This new type conforms to the BodyParameters protocol and allows developers to serialize plain text as the HTTP request body. It automatically sets the Content-Type header to text/plain, ensuring that the request meets the server's expectations.

By adding TextPlainParameters, APIKit can now seamlessly handle situations where the AdServices API requires the request body to be in plain text format. This improvement not only facilitates smoother integration with the AdServices API but also increases the flexibility of APIKit when working with other APIs that expect plain text request bodies.

This pull request aims to provide developers with a convenient way to interact with the AdServices API using APIKit, while also extending the library's capabilities to support a wider range of API requirements.

Please let me know if there's any problem or question. Thank you.